### PR TITLE
2.3.1

### DIFF
--- a/fw/src/app/player/view/player_view.c
+++ b/fw/src/app/player/view/player_view.c
@@ -62,6 +62,7 @@ player_view_t *player_view_create() {
 
     p_player_view->p_view = p_view;
     p_player_view->frame_buffer = NULL;
+    p_player_view->is_playing = false;
 
     p_player_view->frame_tick_timer_id = &p_player_view->frame_tick_timer_data;
     int32_t err_code =


### PR DESCRIPTION
这是个BUGFIX版本。

可以用NRFConnect或者 [网页](https://pixl.amiibo.xyz/) 进入DFU模式后更新固件。

# 更新记录
[BUGFIX] 修复动画播放器菜单返回主菜单卡住的BUG