### PR TITLE
2.6.1

### DIFF
--- a/fw/application/src/app/amiibolink/scene/amiibolink_scene_main.c
+++ b/fw/application/src/app/amiibolink/scene/amiibolink_scene_main.c
@@ -117,6 +117,8 @@ static void amiibolink_scene_switch_mode(app_amiibolink_t *app, ble_amiibolink_m
     amiibolink_view_set_index(app->p_amiibolink_view, initial_index);
     amiibolink_view_set_max_size(app->p_amiibolink_view, MAX_NTAG_INDEX);
 
+    ble_amiibolink_set_mode(mode);
+
     if(mode == BLE_AMIIBOLINK_MODE_NTAG){
         ntag_reload(app, DEFAULT_NTAG_INDEX);
     }else if(mode == BLE_AMIIBOLINK_MODE_CYCLE){

--- a/fw/application/src/mod/ble/ble_amiibolink.h
+++ b/fw/application/src/mod/ble/ble_amiibolink.h
@@ -52,5 +52,6 @@ void ble_amiibolink_init(void);
 void ble_amiibolink_set_event_handler(ble_amiibolink_event_handler_t handler, void* context);
 void ble_amiibolink_received_data(const uint8_t *data, size_t length);
 void ble_amiibolink_set_version(ble_amiibolink_ver_t ver);
+void ble_amiibolink_set_mode(ble_amiibolink_mode_t mode);
 
 #endif

--- a/fw/application/src/mod/df/df_buffer.h
+++ b/fw/application/src/mod/df/df_buffer.h
@@ -126,6 +126,12 @@ static inline void buff_put_string(buffer_t *buffer, char *string) {
     buff_put_byte_array(buffer, string, len);
 }
 
+static inline void buff_put_string_u8(buffer_t *buffer, char *string) {
+    uint8_t len = strlen(string);
+    buff_put_u8(buffer, len);
+    buff_put_byte_array(buffer, string, len);
+}
+
 static inline uint64_t buff_get_u64(buffer_t *buffer) {
     uint64_t value = 0;
     value = *(uint32_t *)(&buffer->buff[buffer->pos]);

--- a/fw/application/src/utils.c
+++ b/fw/application/src/utils.c
@@ -10,12 +10,20 @@
 #include "nrf_sdh.h"
 #include "nrf_soc.h"
 #include "nrf_nvic.h"
+#include "string.h"
+#include "nrf52.h"
 
 ret_code_t utils_rand_bytes(uint8_t rand[], uint8_t bytes) {
     ret_code_t err;
     while ((err = sd_rand_application_vector_get(rand, bytes)) == NRF_ERROR_SOC_RAND_NOT_ENOUGH_VALUES) {
     };
     return err;
+}
+
+
+void utils_get_device_id(uint8_t* p_device_id){
+    memcpy(p_device_id, &(NRF_FICR->DEVICEID[0]), 4);
+    memcpy(p_device_id + 4, &(NRF_FICR->DEVICEID[1]), 4);
 }
 
 void enter_dfu() {

--- a/fw/application/src/utils.h
+++ b/fw/application/src/utils.h
@@ -12,6 +12,7 @@
 #include "sdk_errors.h"
 
 ret_code_t utils_rand_bytes(uint8_t rand[], uint8_t bytes);
+void utils_get_device_id(uint8_t* p_device_id);
 void enter_dfu();
 
 


### PR DESCRIPTION
这是个BUGFIX版本。

可以用NRFConnect或者 [网页](https://pixl.amiibo.xyz/) 进入DFU模式后更新固件。
iOS用户推荐使用 iNFC 一键更新最新固件。

# 更新记录
[BUGFIX] 修复amiibolink无法使用最新版本的NFC Tag Pro助手小程序的问题