### PR TITLE
2.8.3

### DIFF
--- a/fw/application/src/amiibo_helper.c
+++ b/fw/application/src/amiibo_helper.c
@@ -115,7 +115,7 @@ ret_code_t amiibo_helper_sign_new_ntag(ntag_t *old_ntag, ntag_t *new_ntag) {
     // encrypt
     amiibo_helper_get_uuid(new_ntag, new_uuid);
     amiibo_helper_replace_uuid(modified, new_uuid);
-
+    amiibo_helper_set_defaults(modified, new_uuid);
     nfc3d_amiibo_pack(&amiibo_keys, modified, new_ntag->data);
 
     return NRF_SUCCESS;


### PR DESCRIPTION
这是个BUGFIX版本。

可以用NRFConnect或者 [网页](https://pixl.amiibo.xyz/) 进入DFU模式后更新固件。
iOS用户推荐使用 iNFC 一键更新最新固件。

# 更新记录
* 【问题修复】 修复在Amiibo模拟器应用下无法自动随机的问题 #105 

