### PR TITLE
Add variable names to support different BIN dump sizes

### DIFF
--- a/fw/application/src/app/amiibo/scene/amiibo_scene_amiibo_detail.c
+++ b/fw/application/src/app/amiibo/scene/amiibo_scene_amiibo_detail.c
@@ -187,7 +187,7 @@ static void amiibo_scene_amiibo_detail_reload_files(app_amiibo_t *app) {
             vfs_meta_t meta;
             memset(&meta, 0, sizeof(vfs_meta_t));
             vfs_meta_decode(obj.meta, sizeof(obj.meta), &meta);
-            if (obj.type == VFS_TYPE_REG && (obj.size == NTAG_DATA_SIZE || obj.size == 532 || obj.size == 572) &&
+            if (obj.type == VFS_TYPE_REG && (obj.size == NTAG_DATA_SIZE || obj.size == NTAG_TAGMO_DATA_SIZE || obj.size == NTAG_THENAYA_DATA_SIZE) &&
                 (!meta.has_flags || !(meta.flags & VFS_OBJ_FLAG_HIDDEN))) {
                 string_set_str(file_name, obj.name);
                 string_array_push_back(app->amiibo_files, file_name);

--- a/fw/application/src/ntag/ntag_def.h
+++ b/fw/application/src/ntag/ntag_def.h
@@ -12,6 +12,8 @@
 #include <stdbool.h>
 
 #define NTAG_DATA_SIZE 540
+#define NTAG_TAGMO_DATA_SIZE 532
+#define NTAG_THENAYA_DATA_SIZE 572
 
 typedef enum
 {


### PR DESCRIPTION
Add the variables NTAG_TAGMO_DATA_SIZE & NTAG_THENAYA_DATA_SIZE to allows BIN Dumps with 532 y 572 sizes.