### PR TITLE
New Settings language selection logic

### DIFF
--- a/docs/en/05+5-translation.md
+++ b/docs/en/05+5-translation.md
@@ -16,9 +16,8 @@ The script `font_data_gen.sh` only can be run in Git Bash windows in Windows.
 2. Run `fw/scripts/i18n_gen.py` to generate new language files.
 3. Optional: Run `fw/scripts/font_data_gen.sh` to generate new font data if you add new charaters in i18n.csv
 4. Edit `fw/application/src/i18n/language.h` and `fw/application/src/i18n/language.c` to adopt new language
-5. Edit `fw/application/src/app/settings/scene/settings_scene_language.c` to adopt new language
-6. Edit Makefile to include `$(PROJ_DIR)/i18n/ja_JP.c` as C source files
-7. Run `make full` rebuild firmware
+5. Edit Makefile to include `$(PROJ_DIR)/i18n/ja_JP.c` as C source files
+6. Run `make full` rebuild firmware
 
 ## Font notes 
 

--- a/fw/application/src/app/settings/scene/settings_scene_language.c
+++ b/fw/application/src/app/settings/scene/settings_scene_language.c
@@ -7,59 +7,29 @@
 #include "utils2.h"
 #include "version2.h"
 
-enum settings_sleep_timeout_menu_t {
-    SETTINGS_LANGUAGE_ZH_HANS,
-    SETTINGS_LANGUAGE_EN_US,
-    SETTINGS_LANGUAGE_ZH_TW,
-    SETTINGS_LANGUAGE_ES_ES,
-    SETTINGS_LANGUAGE_HU_HU,
-    SETTINGS_LANGUAGE_KO_KR,
-    SETTINGS_LANGUAGE_MENU_EXIT,
-};
+int SetLangOpt;
 
 static void settings_scene_language_list_view_on_selected(mui_list_view_event_t event, mui_list_view_t *p_list_view,
                                                           mui_list_item_t *p_item) {
+
     app_settings_t *app = p_list_view->user_data;
     uint32_t selection = (uint32_t)p_item->user_data;
     settings_data_t *p_settings = settings_get_data();
-    switch (selection) {
-    case SETTINGS_LANGUAGE_ZH_HANS:
-        p_settings->language = LANGUAGE_ZH_HANS;
+    if (selection < LANGUAGE_COUNT){
+        p_settings->language = selection;
         setLanguage(p_settings->language);
-        break;
-
-    case SETTINGS_LANGUAGE_EN_US:
-        p_settings->language = LANGUAGE_EN_US;
-        setLanguage(p_settings->language);
-        break;
-
-    case SETTINGS_LANGUAGE_ZH_TW:
-        p_settings->language = LANGUAGE_ZH_TW;
-        setLanguage(p_settings->language);
-        break;
-
-    case SETTINGS_LANGUAGE_ES_ES:
-        p_settings->language = LANGUAGE_ES_ES;
-        setLanguage(p_settings->language);
-        break;
-
-    case SETTINGS_LANGUAGE_HU_HU:
-        p_settings->language = LANGUAGE_HU_HU;
-        setLanguage(p_settings->language);
-        break;
     }
+
     mui_scene_dispatcher_previous_scene(app->p_scene_dispatcher);
 }
 
 void settings_scene_language_on_enter(void *user_data) {
 
     app_settings_t *app = user_data;
-    mui_list_view_add_item(app->p_list_view, 0xe105, "简体中文", (void *)SETTINGS_LANGUAGE_ZH_HANS);
-    mui_list_view_add_item(app->p_list_view, 0xe105, "繁體中文(臺灣)", (void *)SETTINGS_LANGUAGE_ZH_TW);
-    mui_list_view_add_item(app->p_list_view, 0xe105, "English", (void *)SETTINGS_LANGUAGE_EN_US);
-    mui_list_view_add_item(app->p_list_view, 0xe105, getLangDesc(LANGUAGE_ES_ES), (void *)SETTINGS_LANGUAGE_ES_ES);
-    mui_list_view_add_item(app->p_list_view, 0xe105, getLangDesc(LANGUAGE_HU_HU), (void *)SETTINGS_LANGUAGE_HU_HU);
-    mui_list_view_add_item(app->p_list_view, 0xe069, getLangString(_L_BACK), (void *)SETTINGS_LANGUAGE_MENU_EXIT);
+    for (SetLangOpt = 0; SetLangOpt < LANGUAGE_COUNT; SetLangOpt++){
+      mui_list_view_add_item(app->p_list_view, 0xe105, getLangDesc(SetLangOpt), (void *)SetLangOpt);
+    }
+    mui_list_view_add_item(app->p_list_view, 0xe069, getLangString(_L_BACK), (void *)SetLangOpt);
 
     mui_list_view_set_selected_cb(app->p_list_view, settings_scene_language_list_view_on_selected);
     mui_view_dispatcher_switch_to_view(app->p_view_dispatcher, SETTINGS_VIEW_ID_MAIN);

--- a/fw/application/src/i18n/language.c
+++ b/fw/application/src/i18n/language.c
@@ -8,13 +8,13 @@ typedef struct {
 
 LanguageData languageData[LANGUAGE_COUNT] = {
     [LANGUAGE_ZH_HANS] = { .strings = lang_zh_Hans },
-    [LANGUAGE_EN_US] = { .strings = lang_en_US },
     [LANGUAGE_ZH_TW] = { .strings = lang_zh_TW },
+    [LANGUAGE_EN_US] = { .strings = lang_en_US },
     [LANGUAGE_ES_ES] = { .strings = lang_es_ES },
     [LANGUAGE_HU_HU] = { .strings = lang_hu_HU },
 };
 
-// 当前语言设置
+// 当前语言设置 (Current language setting)
 Language currentLanguage = LANGUAGE_ZH_HANS;
 
 
@@ -30,10 +30,10 @@ void setLanguage(Language lang) {
 const char* getLangDesc(Language lang){
     if(lang == LANGUAGE_ZH_HANS){
         return "简体中文";
-    }else if(lang == LANGUAGE_EN_US){
-        return "English";
     }else if(lang == LANGUAGE_ZH_TW){
         return "繁體中文(臺灣)";
+    }else if(lang == LANGUAGE_EN_US){
+        return "English";
     }else if(lang == LANGUAGE_ES_ES){
         return  "Español";
     }else if(lang == LANGUAGE_HU_HU){

--- a/fw/application/src/i18n/language.h
+++ b/fw/application/src/i18n/language.h
@@ -12,20 +12,20 @@
 
 typedef enum {
     LANGUAGE_ZH_HANS,
-    LANGUAGE_EN_US,
     LANGUAGE_ZH_TW,
+    LANGUAGE_EN_US,
     LANGUAGE_ES_ES,
     LANGUAGE_HU_HU,
     LANGUAGE_COUNT
 } Language;
 
-extern const char* lang_en_US[_L_COUNT];
 extern const char* lang_zh_Hans[_L_COUNT];
 extern const char* lang_zh_TW[_L_COUNT];
+extern const char* lang_en_US[_L_COUNT];
 extern const char* lang_es_ES[_L_COUNT];
 extern const char* lang_hu_HU[_L_COUNT];
 
-// 获取字符串的函数
+// 获取字符串的函数 (Get language string function)
 const char* getLangString(L_StringID stringID);
 void setLanguage(Language lang);
 Language getLanguage();


### PR DESCRIPTION
# docs\en\05+5-translation.md
Reverting to last one, because now `fw\application\src\app\settings\scene\settings_scene_language.c` is independent to add/remove/modify language definitions.

# fw\application\src\app\settings\scene\settings_scene_language.c
Remove the need of manually add languages here, most of the code changed to automatized one.

# Language Order
Due to the automation of `fw\application\src\app\settings\scene\settings_scene_language.c` now the order of the languages on the settings menu selection are dependent to the order of the definitions of the variable on the `fw\application\src\i18n\language.c` and `fw\application\src\i18n\language.h` files.