### PR TITLE
Make language settings more robust.

### DIFF
--- a/fw/application/src/main.c
+++ b/fw/application/src/main.c
@@ -277,6 +277,9 @@ int main(void) {
 
     NRF_LOG_DEBUG("init done");
 
+    if (p_settings->language >= LANGUAGE_COUNT) {
+        p_settings->language = LANGUAGE_EN_US;
+    }
     setLanguage(p_settings->language);
     
     mui_t *p_mui = mui();


### PR DESCRIPTION
Added bound check for the current language. If a user downgrades a firmware, the active language could go out of bounds (if the older firmware has less supported languages).