### PR TITLE
Replacing the remaining manually bracketed _L_ON/OFF with special initially bracketed _L_ON_F/OFF_F

### DIFF
--- a/fw/application/src/app/amiidb/scene/amiidb_scene_amiibo_detail_menu.c
+++ b/fw/application/src/app/amiidb/scene/amiidb_scene_amiibo_detail_menu.c
@@ -95,8 +95,8 @@ static void amiidb_scene_amiibo_detail_menu_on_selected(mui_list_view_event_t ev
         char txt[32];
         settings_data_t *p_settings = settings_get_data();
         p_settings->auto_gen_amiibo = !p_settings->auto_gen_amiibo;
-        snprintf(txt, sizeof(txt), "[%s]",
-                 p_settings->auto_gen_amiibo ? getLangString(_L_ON) : getLangString(_L_OFF));
+        snprintf(txt, sizeof(txt), "%s",
+                 p_settings->auto_gen_amiibo ? getLangString(_L_ON_F) : getLangString(_L_OFF_F));
         settings_save();
 
         string_set_str(p_item->sub_text, txt);
@@ -108,7 +108,7 @@ static void amiidb_scene_amiibo_detail_menu_on_selected(mui_list_view_event_t ev
         char txt[32];
         settings_data_t *p_settings = settings_get_data();
         p_settings->qrcode_enabled = !p_settings->qrcode_enabled;
-        snprintf(txt, sizeof(txt), "[%s]", p_settings->qrcode_enabled ? getLangString(_L_ON) : getLangString(_L_OFF));
+        snprintf(txt, sizeof(txt), "%s", p_settings->qrcode_enabled ? getLangString(_L_ON_F) : getLangString(_L_OFF_F));
         settings_save();
 
         string_set_str(p_item->sub_text, txt);
@@ -139,11 +139,11 @@ void amiidb_scene_amiibo_detail_menu_on_enter(void *user_data) {
     char txt[32];
     settings_data_t *p_settings = settings_get_data();
 
-    snprintf(txt, sizeof(txt), "[%s]", p_settings->auto_gen_amiibo ? getLangString(_L_ON) : getLangString(_L_OFF));
+    snprintf(txt, sizeof(txt), "%s", p_settings->auto_gen_amiibo ? getLangString(_L_ON_F) : getLangString(_L_OFF_F));
     mui_list_view_add_item_ext(app->p_list_view, 0xe1c6, getLangString(_L_AUTO_RANDOM_GENERATION), txt,
                                (void *)AMIIDB_DETAIL_MENU_AUTO_RAND_UID);
 
-    snprintf(txt, sizeof(txt), "[%s]", p_settings->qrcode_enabled ? getLangString(_L_ON) : getLangString(_L_OFF));
+    snprintf(txt, sizeof(txt), "%s", p_settings->qrcode_enabled ? getLangString(_L_ON_F) : getLangString(_L_OFF_F));
     mui_list_view_add_item_ext(app->p_list_view, 0xe006, getLangString(_L_SHOW_QRCODE), txt,
                                (void *)AMIIDB_DETAIL_MENU_SHOW_QRCODE);
     mui_list_view_add_item(app->p_list_view, ICON_FAVORITE, getLangString(_L_APP_AMIIDB_DETAIL_FAVORITE),

--- a/fw/application/src/app/settings/scene/settings_scene_main.c
+++ b/fw/application/src/app/settings/scene/settings_scene_main.c
@@ -169,7 +169,7 @@ static void settings_scene_main_reload(void *user_data) {
                                (void *)SETTINGS_MAIN_MENU_OLED_CONTRAST);
 #else
     if (p_settings->lcd_backlight == 0) {
-        snprintf(txt, sizeof(txt), "[%s]", getLangString(_L_OFF));
+        snprintf(txt, sizeof(txt), "%s", getLangString(_L_OFF_F));
     } else {
         snprintf(txt, sizeof(txt), "[%d%%]", p_settings->lcd_backlight);
     }

--- a/fw/application/src/i18n/ru_RU.c
+++ b/fw/application/src/i18n/ru_RU.c
@@ -1,7 +1,7 @@
 #include "string_id.h"
 const char * const lang_ru_RU[_L_COUNT] = {
-    [_L_ON] = "Вкл",
-    [_L_OFF] = "Выкл",
+    [_L_ON] = "Включено",
+    [_L_OFF] = "Выключено",
     [_L_ON_F] = "[Вкл]",
     [_L_OFF_F] = "[Выкл]",
     [_L_BACK] = "[Назад]",

--- a/fw/data/i18n.csv
+++ b/fw/data/i18n.csv
@@ -1,6 +1,6 @@
 CODE,en_US,zh_Hans,zh_TW,es_ES,hu_HU,de_DE,fr_FR,nl_NL,pt_BR,ja_JP,it_IT,ru_RU
-_L_ON,ON,开,開,SI,BE,AN,ACTIVÉ,AAN,LIGADO,オン,SI,Вкл
-_L_OFF,OFF,关,關,NO,KI,AUS,DÉSACTIVÉ,UIT,DESLIGADO,オフ,NO,Выкл
+_L_ON,ON,开,開,SI,BE,AN,ACTIVÉ,AAN,LIGADO,オン,SI,Включено
+_L_OFF,OFF,关,關,NO,KI,AUS,DÉSACTIVÉ,UIT,DESLIGADO,オフ,NO,Выключено
 _L_ON_F,[ON],[开],[開],[SI],[BE],[AN],[ACTIVÉ],[AAN],[LIGADO],[オン],[SI],[Вкл]
 _L_OFF_F,[OFF],[关],[關],[NO],[KI],[AUS],[DÉSACTIVÉ],[UIT],[DESLIGADO],[オフ],[NO],[Выкл]
 _L_BACK,Back,返回,返回,[Atrás],Vissza,Zurück,Retour,Terug,Voltar,戻る,Indietro,[Назад]


### PR DESCRIPTION
In theory this should finish issue https://github.com/solosky/pixl.js/issues/237.
Practically - I don’t know if this will ruin anything else, I’m not a programmer. So far everything seems to be fine (at least for me).

It's also "improves" the translation of the lines _L_ON/OFF “freed” by this in order to more elegantly display what they are left to display now.