### PR TITLE
Prevent being stuck on the chameleon rename screen.

### DIFF
--- a/fw/application/src/app/chameleon/scene/chameleon_scene_menu_card_set_name.c
+++ b/fw/application/src/app/chameleon/scene/chameleon_scene_menu_card_set_name.c
@@ -30,6 +30,7 @@ static void chameleon_scene_menu_card_set_name_text_input_event_cb(mui_text_inpu
             int32_t err = tag_helper_set_nickname(text);
             if (err != 0) {
                 mui_toast_view_show(app->p_toast_view, _T(APP_CHAMELEON_CARD_SET_NICK_FAILED));
+                mui_scene_dispatcher_previous_scene(app->p_scene_dispatcher);
                 return;
             }
             mui_toast_view_show(app->p_toast_view, _T(APP_CHAMELEON_CARD_SET_NICK_SUCCESS));


### PR DESCRIPTION
Renaming an uninitialized card chameleon card always fails. This change makes sure the user will be backed out of the screen when that happens, instead of being permanently stuck on the naming screen.