### PR TITLE
Add Korean translations to i18n.csv

### DIFF
--- a/fw/data/i18n.csv
+++ b/fw/data/i18n.csv
@@ -1,185 +1,185 @@
-CODE,en_US,zh_Hans,zh_TW,es_ES,hu_HU,de_DE,fr_FR,nl_NL,pt_BR,ja_JP,pt_PT,it_IT,ru_RU
-_L_ON,ON,开,開,SI,BE,AN,ACTIVÉ,AAN,LIGADO,オン,SIM,SI,Включено
-_L_OFF,OFF,关,關,NO,KI,AUS,DÉSACTIVÉ,UIT,DESLIGADO,オフ,NÃO,NO,Выключено
-_L_ON_F,[ON],[开],[開],[SI],[BE],[AN],[ACTIVÉ],[AAN],[LIGADO],[オン],[SIM],[SI],[Вкл]
-_L_OFF_F,[OFF],[关],[關],[NO],[KI],[AUS],[DÉSACTIVÉ],[UIT],[DESLIGADO],[オフ],[NÃO],[NO],[Выкл]
-_L_BACK,Back,返回,返回,[Atrás],Vissza,Zurück,Retour,Terug,Voltar,戻る,Voltar,Indietro,[Назад]
-_L_ERR,Error,错误,錯誤,Error,Hiba,Fehler,Erreur,Fout,Erro,エラー,Erro,Errore,Ошибка
-_L_ERR_CODE,Error Code,错误码,錯誤碼,Código error,Hibakód,Fehlercode,Code d'Erreur,Foutcode,Código de Erro,エラーコード,Código de Erro,Codice errore,Код ошибки
-_L_FAILED,Failed,失败,失敗,,,,,,,,,,Ошибка
-_L_APP_AMIIBO,Amiibo Emulator,Amiibo模拟器,Amiibo模擬器,Emulador de amiibo,Amiibo Emulátor,Amiibo Emulator,Emulateur Amiibo,Amiibo-Emulator,Emulador de Amiibo,Amiiboエミュレータ,Emulador de Amiibo,Emulatore Amiibo,Эмулятор Amiibo
-_L_APP_AMIIBOLINK,AmiiboLink,AmiiboLink,AmiiboLink,AmiiboLink,AmiiboLink,AmiiboLink,AmiiboLink,AmiiboLink,AmiiboLink,AmiiboLink,AmiiboLink,AmiiboLink,AmiiboLink
-_L_APP_BLE,BLE File Transfer,蓝牙传输,藍牙傳送,Transferencia BLE,BLE Fájltovábbítás,BLE Dateitransfer,Transfert de Fichiers BLE,BLE Bestandsoverdracht,Transferência de Arquivos BLE,BLEファイル転送,Transferência BLE,Trasferimento file BLE,Передача файлов
-_L_APP_BLE_TITLE,BLE File Transfer,蓝牙传输,藍牙傳送,Transferencia BLE,BLE Fájltovábbítás,BLE Dateitransfer,Transfert de Fichiers BLE,BLE Bestandsoverdracht,Transferência de Arquivos BLE,BLEファイル転送,Transferência BLE,Trasferimento file BLE,по Bluetooth
-_L_APP_PLAYER,Video Player,动画播放器,動畫播放器,Reproductor vídeo,Video Lejátszó,Videoplayer,Lecteur Vidéo,Videospeler,Reprodutor de Vídeo,ビデオプレーヤー,Reprodutor de vídeo,Lettore video,Видеоплеер
-_L_APP_SET,Settings,系统设置,系統設定,Configuraciones,Beállítások,Einstellungen,Paramètres,Instellingen,Configurações,設定,Definições,Impostazioni,Настройки
-_L_APP_SET_VERSION,Version,版本,版本,Versión,Verzió,Version,Version,Versie,Versão,バージョン,Versão,Versione,Версия
-_L_APP_SET_STORAGE_USED,Used,已用,已用,Usado,Használt,Belegt,Utilisé,Gebruikt,Usado,使用ストレージ,Usada,Usato,Занято
-_L_APP_SET_STORAGE,External Storage,外置存储,外置存儲,M. Flash,Külső Tároló,Externer Speicher,Stockage Externe,Externe Opslag,Armazenamento Externo,外部ストレージ,Memoria Externa,Memoria esterna,Накопитель
-_L_APP_SET_OLED_CONTRAST,Contrast,对比度,對比度,Contraste OLED,Kontraszt,Kontrast,Contraste,Contrast,Contraste do,コントラスト,Contraste,Contrasto,Контрастность
-_L_APP_SET_OLED_CONTRAST_TITLE,Contrast,对比度,對比度,Contraste OLED,Kontraszt,Kontrast,Contraste,Contrast,Contraste do,コントラスト,Contraste,Contrasto,Контраст OLED
-_L_APP_SET_LCD_BACKLIGHT,Backlight,背光亮度,背光亮度,Brillo,Háttérvilágítás,Beleuchtung,Rétroéclairage,Achtergrondverlichting,Luz de Fundo,バックライト,Brilho,Luminosità,Подсветка
-_L_APP_SET_LCD_BACKLIGHT_TITLE,Backlight Brightness,背光亮度,背光亮度,Brillo de fondo,Háttérvilágítás Fényerő,Helligkeit,Luminosité du Rétroéclairage,Helderheid Achtergrondverlichting,Brilho da Luz de Fundo,バックライトの明るさ,Brilho do Ecrã,Luminosità schermo,Яркость подсветки
-_L_APP_SET_ANIM,Menu Animation,动画效果,動畫效果,Animar menú,Menü Animáció,Menü Animation,Animation du Menu,Menu-Animatie,Animação do Menu,メニュー アニメーション,Animação do Menu,Animazione menu,Анимация меню
-_L_APP_SET_LIPO_BAT,LiPO Battery,LiPO电池,LiPO電池,Batería LiPO,LiPO Akkumulátor,LiPO Batterie,Batterie LiPO,LiPO-Batterij,Bateria LiPO,LiPOバッテリー,Bateria LiPO,Batteria LiPO,Батарея LiPO
-_L_APP_SET_SHOW_MEM_USAGE,Memory Used,内存使用率,記憶體使用率,Estad. Mem.,Használt Memória,Speicheranzeige,Mémoire Utilisée,Gebruikt Geheugen,Memória Usada,使用メモリ,Memoria Usada,Memoria usata,Статус памяти
-_L_APP_SET_HIBERNATE,Fast Wakeup,快速唤醒,快速喚醒,Hibernar,Gyors Ébresztés,Schnelles Aufwachen,Réveil Rapide,Snel Ontwaken,Despertar Rápido,高速起動,Suspender,Risveglio rapido,Гибернация
-_L_APP_SET_SLEEP_TIMEOUT,Sleep Timeout,休眠时间,休眠時間,Dormir en:,Alvási Időkorlát,Standby nach,Délai de mise en veille,Time-out Slaapstand,Tempo Limite de Suspensão,スリープタイムアウト,Suspender em:,Timeout di sospensione,Таймаут сна
-_L_APP_SET_LANGUAGE,Language,系统语言,系統語言,Idioma,Nyelv,Sprache,Langue,Taal,Idioma,言語,Idioma,Lingua,Язык
-_L_APP_SET_GO_SLEEP,Go Sleep,进入休眠,進入休眠,,,,,,,,,,В режим сна
-_L_APP_SET_DFU,Firmware Update,固件更新,軟體升級,Actualizar firmware,Firmware Frissítés,Firmw. Aktualisierung,Mise à Jour du Micrologiciel,Firmware Bijwerken,Atualização de Firmware,ファームウェア更新,Atualizações,Aggiornamento firmware,Обновление ПО
-_L_APP_SET_REBOOT,System Reboot,重启设备,重啟設備,Reiniciar,Rendszer Újraindítása,System Neustart,Redémarrage du Système,Systeem Herstarten,Reinicialização do Sistema,システム再起動,Reiniciar,Riavvio del sistema,Перезагрузка
-_L_APP_SET_RESET_DEFAULT,Reset Default Setting,重置默认配置,重置默認配置,Restablecer config.,Alapért. Beállítás Visszaállítása,Standardeinstellungen,Rétablir les Paramètres par Défaut,Terugzetten Naar Standaardwaarden,Restaurar Configurações Padrão,デフォルト設定に戻す,Repor Definições,Ripristina impostazioni predefinite,Сброс настроек
-_L_APP_SET_RESET_DEFAULT_SUCCESS,Reset Success!,重置成功,重置成功,¡Configuración Restablecida!,Alapért. Beállítások Visszaállítása,Einstellungen zurückgesetzt!,Réinitialiser les Paramètres Par Défaut,Standaardinstellingen Herstellen,Redefinir a Configuração Padrão,設定を初期化,Reposição Completa!,Ripristino riuscito!,Сброс выполнен
-_L_APP_SET_RESET_DEFAULT_CONFIRM,Confirm Reset Settings?,确认重置默认设置？,确认重置默认设置？,¿Confirma Restablecer\nConfig.?,,Auf Standardeinstellungen zurücksetzen?,,,,,,Conferma il ripristino delle impostazioni?,Выполнить?
-_L_APP_SET_ABOUT,About Device,关于设备,關於設俻,Acerca del dispositivo,,,,,,,,,Об устройстве
-_L_APP_SET_ABOUT_OPEN_SOURCE_PROJECT,Open Source Project,开源项目,開源項目,Poyecto de código abierto,,,,,,,,,Проект с открытым кодом
-_L_APP_SET_ABOUT_LGPL_LICENSE,GPL 2.0 License,GPL 2.0 授权,GPL 2.0 授權,Licencia GPL 2.0,,,,,,,,,Лицензия GPL 2.0
-_L_15S,15 Seconds,15秒,15秒,15 segundos,15 sec.,15 Sekunden,15 sec.,15 sec.,15 seg.,15秒,15 segundos,15 secondi,15 секунд
-_L_30S,30 Seconds,30秒,30秒,30 segundos,30 sec.,30 Sekunden,30 sec.,30 sec.,30 seg.,30秒,30 segundos,30 secondi,30 секунд
-_L_45S,45 Seconds,45秒,45秒,45 segundos,45 sec.,45 Sekunden,45 sec.,45 sec.,45 seg.,45秒,45 segundos,45 secondi,45 секунд
-_L_1MIN,1 Minute,1分钟,1分鐘,1 minuto,1 min.,1 Minute,1 min.,1 min.,1 min.,1分,1 minuto,1 minuto,1 минута
-_L_2MIN,2 Minutes,2分钟,2分鐘,2 minutos,2 min.,2 Minuten,2 min.,2 min.,2 min.,2分,2 minutos,2 minuti,2 минуты
-_L_3MIN,3 Minutes,3分钟,3分鐘,3 minutos,3 min.,3 Minuten,3 min.,3 min.,3 min.,3分,3 minutos,3 minuti,3 минуты
-_L_AMIIBO_KEY_UNLOADED,Amiibo Key not loaded,Amiibo Key未加载,Amiibo Key未載入,Sin llave amiibo,Amiibo kulcs nincs betöltve,Amiibo Schlüssel fehlt,Clé Amiibo Non Chargée,Amiibo-Sleutel Niet Geladen,A chave Amiibo não foi carregada,Amiiboキーが読み込まれない,Amiibo Key não encontrada,Chiave Amiibo non caricata,Отсутствует файл ключа
-_L_UPLOAD_KEY_RETAIL_BIN,Upload the file key_retail.bin to the root directory of the storage.,上传文件 key_retail.bin\n到存储根目录下。,上傳檔案 key_retail.bin\n到儲存根目錄下。,Suba el archivo\nkey_retail.bin\nal directorio raíz.,Töltse fel a key_retail.bin fájlt a gyökérkönyvtárába.,Platzieren Sie die Datei key_retail.bin im Hauptverzeichnis des Speichers.,Téléchargez le fichier key_retail.bin dans le répertoire racine du stockage.,Upload het bestand key_retail.bin naar de hoofdmap van de opslag.,Carregue o arquivo key_retail.bin no diretório raiz do armazenamento.,key_retail.binファイルをストレージのルートディレクトリにアップロードする。,Carregue o ficheiro key_retail.bin para a raiz do dispositivo.,Carica il file key_retail.bin nella directory root della memoria.,Поместите key_retail.bin\n в корень накопителя
-_L_KNOW,Got it,知道了,知道了,Entendido,Megvan,Verstanden,Compris,Begrepen,Entendi,了解,Confirmado,Ho Capito,[Понятно]
-_L_RANDOM_GENERATION,Rand. Tag,随机生成,隨機產生,Nuevo serial aleat.,Véletlengenerátor,Zufällige UUID,Randomiser la Balise,Willekeurige Tag,Randomizar Etiqueta,タグのランダム化,Tag Aleatória,Tag casuale,Сгенерировать UUID
-_L_AUTO_RANDOM_GENERATION,Auto Rand.,自动随机生成,自動隨機產生,Serial alea. aut,Automat. Véletlengenerátor,Zufällige UUID (Automatisch),Randomisation Automatique,Automatische Randomisatie,Randomização Automática,自動ランダム化,Tag Aleatória Auto.,Casuale automatico,Автогенерация
-_L_SET_CUSTOM_ID,Set Custom ID,自定义 ID,自定義 ID,,,,,,,,,,Заказной ID
-_L_INPUT_ID,Input ID,输入 ID,输入 ID,,,,,,,,,,Задайте ID
-_L_INAVLID_ID,Invalid ID,无效的 ID,無效的 ID,,,,,,,,,,Недопустимый ID
-_L_SHOW_QRCODE,Display QR Code,显示二维码,顯示二維碼,Mostrar QR,QR-kód Megjelenítése,QR Code,Afficher le Code QR,QR-Code Weergeven,Exibir QR Code,QRコード表示,Mostrar código QR,Mostra codice QR,QR-код
-_L_READ_ONLY,Read-only,禁止写入,禁止寫入,,,,,,,,,,Только чтение
-_L_DELETE_TAG,Delete Tag,删除标签,刪除標籤,Borrar amiibo...,Címke Törlése,Tag löschen,Supprimer la Balise,Tag Verwijderen,Excluir Etiqueta,タグの削除,Apagar Tag,Elimina tag,Удалить тег
-_L_DELETE_TAG_CONFIRM,Confirm Delete %s ?,确认删除 %s ?,確認刪除 %s ?,¿Borrar %s?,Törlés Megerősítése?,Löschen von %s bestätigen?,Confirmer la Suppression de %s ?,Bevestig Verwijderen %s ?,Confirmar Exclusão de %s ?,%s を削除しますか？,Apagar %s definitivamente?,Conferma eliminazione %s\n?,Удалить %s?
-_L_BACK_TO_DETAILS,Back to Tag Details,返回详情,返回詳情,[Detalles amiibo],Vissza a Címke Részletkhez,Zurück zu Tag Details,Retour Aux Détails de L'étiquette,Terug naar Tag Details,Voltar Aos Detalhes da Tag,タグの詳細に戻る,Voltar para detalhes,[Torna ai dettagli del tag],[Назад к деталям]
-_L_BACK_TO_FILE_LIST,Back to File List,返回文件列表,返回檔案清單,[Lista Archivos],Vissza a Fájl Listához,Zurück zur Liste,Retour à La Liste Des Fichiers,Terug naar Bestandslijst,Voltar Para a Lista de Arquivos,ファイル一覧に戻る,Voltar para lista,[Torna alla lista dei file],[Назад к списку]
-_L_BACK_TO_MAIN_MENU,Back to Main Menu,返回主菜单,返回主選單,[Menú Principal],Vissza a Főmenübe,Hauptmenü,Retour au Menu Principal,Terug naar Hoofdmenu,Voltar ao Menu Principal,メインメニューに戻る,Voltar para menu principal,[Torna al menu principale],[В главное меню]
-_L_FORMAT,Format,格式化,格式化,Formatear...,Formátum ,Formatieren,Format,Formatteren,Formatar,フォーマット,Formatar,Formatta...,Отформатировать
-_L_FORMAT_STORAGE,Format Storage,格式化存储,格式化儲存,Formatear mem. Flash,Formátum Tárolás,Speicher formatieren,Format de Stockage,Opslag Formatteren,Formatar Armazenamento,保存領域フォーマット,Formatar memória,Formatta memoria,Форматирование
-_L_DELETE_ALL_DATA,This will delete all data. Confirm format?,将删除所有数据。\n确认格式化?,將刪除所有資料。\n確認格式化?,Se borrará todos los\ndatos.,Minden adatot töröl. Formázás megerősítése?,Alle Daten löschen?,Cette opération efface toutes les données. Confirmer le formatage?,Hierdoor worden alle gegevens gewist. Formatteren bevestigen?,Isso excluirá todos os dados. Confirmar a formatação?,これですべてのデータが削除されます。よろしいですか？,Isto vai eliminar todos os dados. Confirmar formtação?,Questo cancellerà tutti i dati.\nConferma la formattazione?,Это удалит все данные.\nВыполнить?
-_L_DELETING_MESSAGE,Formatting ...,格式化中...,格式化中...,Formateando...,Formázás ...,Formatiere...,Formatage ...,Formatteren ...,Formatando ...,書式設定 ...,A Formatar...,Formattazione in corso ...,Форматирование...
-_L_MESSAGE,Message,提示,提示,Inicializar,Üzenet,Meldung,Message,Bericht,Mensagem,メッセージ,A Iniciar,Messaggio,Сообщение
-_L_CONFIRM,Confirm,确定,確定,Confirmar,Megerősítés,Bestätigen,Confirmer,Bevestigen,Confirmar,確認,Confirmar,Conferma,Да
-_L_CANCEL,Cancel,取消,取消,Cancelar,Megszüntet,Abbrechen,Annuler,Annuleren,Cancelar,キャンセル,Cancelar,Annulla,Отмена
-_L_BACK_TO_LIST,Back List,返回列表,返回清單,[Voler a lista],Vissza a Listához,Zurück zur Liste,Retour à La Liste,Terug naar Lijst,Voltar à Lista,バックリスト,Voltar para lista,[Torna alla lista],[Назад к списку]
-_L_NOT_MOUNTED,Not Mounted,未挂载,未掛載,No montado,Nincs Felszerelve,Speicher nicht eingebunden,Stockage non Monté,Niet Gekoppeld,Não Montado,ストレージがマウントされていません,Não montado,Non montato,==[Не подключён]==
-_L_MOUNTED_LFS,===Mounted[LFS]===,===已挂载[LFS]===,===已掛載[LFS]===,===[LFS]Montado===,===Szerelt[LFS]===,===Speicher [LFS]===,===Monté[LFS]===,===Gekoppeld[LFS]===,===Montado[LFS]===,===ストレージマウント[LFS]===,===[LFS]Montado===,===Montato[LFS]===,==Подключён[LFS]==
-_L_MOUNTED_FFS,===Mounted[FFS]===,===已挂载[FFS]===,===已掛載[FFS]===,===[FFS]Montado===,===Szerelt[FFS]===,===Speicher [FFS]===,===Monté[FFS]===,===Gekoppeld[FFS]===,===Montado[FFS]===,===ストレージマウント[FFS]===,===[FFS]Montado===,===Montato[FFS]===,==Подключён[FFS]==
-_L_TOTAL_SPACE,Total,总空间,總空間,Capacidad,Össz.,Gesamt,Total,Totaal,Total,トータル容量,Total,Totale,Ёмкость
-_L_AVAILABLE_SPACE,Free,可用空间,可用空間,Libre,Ingyenes,Frei,Libre,Vrij,Livre,空き容量,Livre,Libero,Свободно
-_L_NOT_AMIIBO_FILE,This is not Amiibo file,这不是Amiibo文件,這不是Amiibo檔案,Este no es un archivo\namiibo válido,Ez nem Amiibo Fájl,Keine Amiibo Datei,Ce n'est pas un fichier Amiibo,Dit is geen Amiibo-bestand,Este Não é um Arquivo Amiibo,これはAmiiboファイルではありません,Ficheiro amiibo incorreto,Questo non è un file\nAmiibo valido,Этот файл не Amiibo
-_L_READ_FILE_FAILED,Failed read the file,读取文件失败,讀取檔案失敗,Error al leer archivo,Fájl beolvasása sikerten,Lesen fehlgeschlagen,Échec de la lecture du fichier,Lezen van het bestand is mislukt,Falha na Leitura do Arquivo,ファイルの読み込みに失敗しました,Falha ao ler ficheiro,Errore nella lettura del file,Ошибка чтения файла
-_L_INPUT_FOLDER_NAME,Input Folder Name:,输入文件夹名:,輸入資料夾名稱:,Nombre carpeta:,Bemeneti Mappa Neve:,Ordnername eingeben:,Nom du Dossier D'entrée:,Naam Invoermap:,Nome da Pasta de Entrada:,入力フォルダ名:,Introduzir nome da pasta:,Nome cartella:,Задайте имя папки:
-_L_INPUT_AMIIBO_NAME,Input Amiibo Name:,输入amiibo名:,輸入amiibo名稱:,Nombre amiibo:,Amiibo Neve:,Amiibo Namen eingeben:,Nom de l'Amiibo D'entrée:,Naam Amiibo Invoeren:,Nome do Amiibo de Entrada:,入力Amiibo名:,Introduzir nome do Amiibo:,Nome Amiibo:,Задайте имя Amiibo:
-_L_DELETE_FILE,Delete %s ?,删除 %s ?,刪除 %s ?,¿Borrar %s?,Törli a %s fájlt?,%s löschen ?,Supprimer le %s ?,%s verwijderen ?,Excluir %s ?,%s を削除しますか ？,,Eliminare %s ?,Удалить %s?
-_L_DELETE,Delete...,删除...,刪除...,Borrar...,Töröl...,Löschen...,Supprimer...,Verwijder...,Excluir...,削除...,Apagar,Elimina...,Удалить...
-_L_TIPS,Confirm,提示,提示,Confirmar,Megerősítés,Bestätigen,Confirmer,Bevestigen,Confirmar,確認する,,Conferma,Внимание
-_L_INPUT_NEW_NAME,Input New Name:,输入新名:,輸入新名稱:,Nuevo nombre:,Új Név Bevitele:,Neuen Namen eingeben:,Nouveau nom D'entrée:,Nieuwe Naam Invoeren:,Novo Nome de Entrada:,新しい名前を入力してください：,Introduzir novo nome:,Nuovo nome:,Задайте новое имя:
-_L_INVALID_INPUT,Invalid Input,无效的输入,無效的輸入,Entrada inválida,Érvénytelen Bemenet,Ungültige Eingabe,Entrée Invalide,Ongeldige Invoer,Entrada Inválida,無効な入力,Entrada inválida,Input non valido,Недопустимый ввод
-_L_CREATE_NEW_FOLDER,Create New Folder...,新建文件夹...,新建資料夾...,Crear carpeta...,Új Mappa Létrehozása...,Neuer Ordner...,Créer un Nouveau Dossier...,Nieuwe Map Maken...,Criar Nova Pasta...,新しいフォルダを作成...,Criar nova pasta...,Crea cartella...,Создать новую папку...
-_L_CREATE_NEW_TAG,Create New Tag...,新建标签...,新建標籤...,Crear amiibo...,Új Címke Létrehozása...,Neuer Tag...,Créer une Nouvelle Étiquette...,Nieuwe Tag Aanmaken...,Criar Nova Tag...,新規タグ作成...,Criar nova Tag...,Crea Amiibo...,Создать новый тег...
-_L_CREATE_NEW_TAG_BATCH,Batch Create New Tag...,批量创建标签...,批量創建標簽...,Crear amiibo en lote...,Kötegelt Új Címke Létrehozása...,Mehrere Tags erstellen...,Créer de Nouvelles Étiquettes Par Lot...,Nieuwe Tags in een Batch Aanmaken...,Criar Novas Tags em Lote...,新規タグの一括作成...,Criar multiplos tags...,Crea Amiibo in serie...,Создать группу тегов...
-_L_INPUT_TAG_NUM,Input Tag Number：,输入标签数量:,輸入標簽數量:,¿Cuántos?,Beviteli Címke Száma:,Tag Anzahl eingeben:,Saisir le Numéro de l'Étiquette:,Labelnummer Invoeren:,Número da Tag de Entrada:,タグ番号を入力:,Quantas tags?,Numero di tag：,Задайте число тегов:
-_L_CREATE_TOO_MANY_NUM,Only max %d tags created in a batch.,一次最多只能创建%d个标签,一次最多只能創建%d個標簽,Sólo se puede crear %d en lote,Max. létrehozható címke egy kötegben %d,Sie können nur maximal %d Tags auf einmal erstellen.,Seulement %d balises maximum créées dans un lot.,Maximum %d tags aangemaakt in een batch.,Somente no máximo %d tags criadas em um lote.,１つのバッチで作成されるタグの数はは最大 %d までです。,O limite de tags é %d.,Numero max di %d tag in serie.,За раз можно создать\n не более %d тегов
-_L_CREATING_TAG_BATCH,Creating tag,创建标签,創建標簽,Creando...,Címke létrehozása,Tag erstellen,Création d'une balise,Tag aanmaken,Criando tag,タグの作成,A Criar Tag,Creazione tag,Создание тега
-_L_CREATING_TAG_FAILED,Create tag %s failed!,写入 %s 标签失败,寫入 %s 標簽失敗,¡Error al crear %s!,Címke létrehozása %s sikertelen!,Erstellen von Tag %s fehlgeschlagen!,La création de la balise %s a échoué!,Aanmaken tag %s mislukt!,Falha ao criar a tag %s!,タグ %s の作成に失敗しました！,Criação de Tag %s falhou!,Creazione tag %s fallita!,Ошибка создания тега %s
-_L_RENAME,Rename...,重命名...,重新命名...,Renombrar...,Átnevezés...,Umbenennen...,Renommer...,Hernoem...,Renomear...,名前の変更...,Renomear ,Rinomina...,Переименовать...
-_L_OPEN_FOLDER_FAILED,Failed to open folder,打开文件夹失败,開啟資料夾失敗,Fallo al abrir carpeta,Mappa megnyitása sikertelen ,Ordner konnte nicht geöffnet werden,Échec de l'ouverture du dossier,Kan map niet openen,Falha ao abrir a pasta,フォルダを開けませんでした,Falha ao abrir pasta,Errore nell'apertura della cartella,Ошибка открытия папки
-_L_RENAME_FAILED,Failed to rename\nError code,重命名失败,重新命名失敗,Fallo al renombrar\nCódigo de error,Átnevezés Sikertelen\nHibakód,Umbenennen fehlgeschlagen\nFehlercode,Échec du renommage.\nCode d'Erreur,Hernoemen mislukt.\nFoutcode,Falha ao renomear\nCódigo de erro,名前の変更に失敗しました。\nエラーコード,Falha ao renomear\nCódigo de Erro,Errore nella rinomina\nCodice errore,Ошибка переименования
-_L_MAIN_RETURN,[RETURN],[返回],[返回],[Volver],[VISSZA],[Zurück],[RETOUR],[TERUG],[RETORNO],[リターン］,[VOLTAR],[Torna indietro],[Назад]
-_L_RANDOM_MODE_MANUAL,Randomize (Manual),随机模式(手动),隨機模式(手動),Aleatorio (Manual),Randomizálás (Kézi),Zufällige UUID (Manuell),Randomiser (Manuel),Willekeurig (Handmatig),Randomizar (Manual),ランダム化 (手動),Aleatório (Manual),Casuale (Manuale),Ручная генерация UUID
-_L_RANDOM_MODE_AUTO,Randomize (Auto),随机模式(自动),隨機模式(自動),Aleatorio (Auto.),Randomizálás (Automat.),Zufällige UUID (Automatisch),Randomiser (Automatique),Willekeurig (Automatisch),Randomizar (Automático),ランダム化(自動),Aleatório (Auto),Casuale (Automatico),Автогенерация UUID
-_L_SEQUENCE_MODE,Sequential mode,按序模式,按序模式,Modo Secuencial,Szekvenciális Mód,Sequentieller Modus,Mode Séquentiel,Sequentiële Modus,Modo Sequencial,シーケンシャルモード,Modo Sequencial,Modo sequenziale,Последовательный
-_L_READ_WRITE_MODE,Read-write mode,读写模式,讀寫模式,Modo Lectura/Escrit.,Olvasás-írás Mód,Lese-Schreibmodus,Mode Lecture-Écriture,Lees-Schrijfmodus,Modo de Leitura e Gravação,読み書きモード,Modo Leitura-Escrita,Modo lettura/scrittura,Чтение-запись
-_L_AMIIBOLINK_V1,V1,V1(历史版本),V1(歷史版本),AmiiboLink V1,V1,V1,V1,V1,V1,V1,V1,V1,V1
-_L_AMIIBOLINK_V2,V2,V2(最新版本),V2(最新版本),AmiiboLink V2,V2,V2,V2,V2,V2,V2,V2,V2,V2
-_L_AMILOOP,AmiLoop,AmiLoop,AmiLoop,AmiLoop,AmiLoop,AmiLoop,AmiLoop,AmiLoop,AmiLoop,AmiLoop,AmiLoop,AmiLoop,AmiLoop
-_L_MODE,Mode,模式,模式,Modo,Mód,Modus,Mode,Modus,Modo,モード,Modo,Modalità,Режим
-_L_AUTO_RANDOM,Auto Random.,自动随机,自動隨機,Aleat. autom.,Automat. Randomizálás,Zufällige UUID (Automatisch),Randomisation Automatique,Automatische Randomisatie,Randomização Automática,自動ランダム化,Modo Aleatório Automático,Auto. casuale,Автогенерация
-_L_COMPATIBLE_MODE,Compati. Mode,兼容模式,相容模式,Compatibil.,Kompatibilis Mód,Kompabilitäts Modus,Mode Compatible,Compatibiliteitsmodus,Modo Compatível,互換モード,Modo Compatibilidade,Mod. Compatibilità,Совместимость
-_L_TAG_DETAILS,[Tag Details],[标签详情],[標籤詳情],[Volver a Detalles],[Tag Részletek],[Zurück zu Details],[Détails de l'Étiquette],[Tag Details],[Detalhes da Tag],[タグ詳細］,[Voltar a detalhes],[Torna ai dettagli],[Назад к деталям]
-_L_MAIN_MENU,[Main Menu],[主菜单],[主選單],[Menú Principal],[Főmenü],[Hauptmenü],[Menu Principal],[Hoofdmenu],[Menu Principal],[メインメニュー］,[Menu Principal],[Menu principale],[В главное меню]
-_L_MODE_RANDOM,Rand. (Manual),随机(手动),隨機(手動),Aleat. man.,Random (Kézi),Zufällige UUID (Manuell),Aléatoire (Manuel),Willekeurig (Handmatig),Randomização (Manual),ランダム化（手動）,Aleatório (Manual),Casuale man.,Ручная генерация
-_L_MODE_CYCLE,Sequential,按序,按序,Secuencial,Szekvenciális,Sequentiell,Séquentiel,Sequentieel,Sequencial,シーケンシャル,Sequencia,Sequenziale,Последовательный
-_L_MODE_NTAG,Read/Write,读写,讀寫,Lect./Escr.,Olvasás/Írás,Lesen/Schreiben,Lecture/Écriture,Lezen/Schrijven,Leitura/gravação,リード/ライト,Leitura/Escrita,Lett./Scritt.,Чтение-запись
-_L_MODE_RANDOM_AUTO_GEN,Rand. (Auto),随机(自动),隨機(自動),Aleat. auto.,Random (Automat.),Zufällig (Auto.),Aléatoire (Automatique),Willekeurig (Automatisch),Randomização (Automática),ランダム化（自動）,Randomização Automática ,Auto. casuale,Автогенерация
-_L_BLANK_TAG,Blank NFC tag,空标签,空標籤,Amiibo no asignado,Üres NFC Címke,Leerer NFC Tag,Étiquette NFC vierge,Lege NFC-tag,Tag NFC em Branco,ブランクNFCタグ,Tag NFC vazia,Amiibo non assegnato,Пустой тег
-_L_APP_AMIIDB,Amiibo Database,Amiibo数据库,Amiibo數據庫,Base datos amiibo,Amiibo Adatbázis,Amiibo Datenbank,Base de Données Amiibo,Amiibo-Database,Banco de Dados Amiibo,Amiiboデータベース,Base de dados Amiibo,Database Amiibo,База данных Amiibo
-_L_APP_AMMIDB_BROWSER,Browser...,查看...,查看...,Explorar...,Böngésző...,Navigieren...,Naviguer...,Browser...,Navegador...,ブラウザ...,Navegar...,Esplora...,Обозреватель...
-_L_APP_AMIIDB_SEARCH,Search...,搜索...,搜索...,Buscar...,Keresés...,Suche...,Recherche...,Zoeken...,Pesquisar...,検索...,Pesquisar...,Cerca...,Поиск...
-_L_APP_AMIIDB_MY_FAVORITES,My Favorites...,我的收藏...,我的收藏...,Mis Favoritos...,Kedvencek...,Meine Favoriten...,Mes Favoris...,Mijn Favorieten...,Meus Favoritos...,お気に入り...,Favoritos...,I miei preferiti...,Моё избранное...
-_L_APP_AMIIDB_MY_TAGS,My Amiibo...,我的数据...,我的數據...,Mis amiibo...,Amiiboim...,Meine Amiibo...,Mes Amiibo...,Mijn Amiibo...,Meu Amiibo...,マイAmiibo...,Os meus amiibos...,I miei Amiibo...,Мои Amiibo...
-_L_APP_AMIIDB_SETTINGS,Settings...,设置...,設置...,Configuraciones...,Beállítások...,Einstellungen...,Paramètres...,Instellingen...,Configurações...,設定...,Definições,Impostazioni...,Настройки...
-_L_APP_AMIIDB_EXIT,[Exit],[退出],[退出],[Menú Principal],[Kilépés],[Beenden],[Quitter],[Afsluiten],[Sair],[終了],[Exit],[Menu principale],[Выход]
-_L_APP_AMIIDB_BACK,[Back],[返回],[返回],[Volver],[Vissza],[Zurück],[Retour],[Terug],[Retornar],[戻る],[Back],[Torna indietro],[Назад]
-_L_APP_AMIIDB_SETTINGS_AMIIBO_KEY,Keys,密钥文件,密鑰文件,Llaves,Kulcsok,Schlüssel,Touches,Toetsen,Teclas,キー,Keys (Chaves),Chiavi,Ключ
-_L_APP_AMIIDB_SETTINGS_AMIIBO_KEY_LOADED,Loaded,已加载,已加載,Cargadas,Betöltve,geladen,Chargée,Geladen,Carregado,ロードされました,Carregado,Caricate,Загружен
-_L_APP_AMIIDB_SETTINGS_AMIIBO_KEY_NOT_LOADED,NOT Loaded,未加载,未加載,NO cargadas,NINCS betöltve,NICHT geladen,NON Chargée,NIET Geladen,NÃO Carregadas,ロードされていません,NÃO carregado,NON caricate,Отсутствует
-_L_APP_AMIIDB_SETTINGS_SLOT_NUM,Slot Num.,数据槽位,數據槽位,Cant. ranuras,Slot Száma,Steckplatzanzahl,Numéro d'Emplacement,Slotnummer,Número do Slot,スロット番号,Slot numero,Num. slot,Число ячеек
-_L_APP_AMIIDB_DETAIL_FAVORITE,Favorite...,收藏...,收藏...,Favorito...,Kedvenc...,Favorit...,Favorite...,Favoriet...,Favorito...,お気に入り...,Favorito,Preferito...,В избранное...
-_L_APP_AMIIDB_DETAIL_SAVE_AS,Save As...,保存为...,保存爲...,Asignar en...,Mentés Másként...,Speichern unter...,Enregistrer Sous...,Opslaan Als...,Salvar como...,名前を付けて保存...,Guardar como..,Assegna a...,Сохранить как...
-_L_APP_AMIIDB_DETAIL_BACK_DETAIL,[Back to Detail],[返回详情],[返回詳情],[Volver a Detalles],[Vissza a Részletekhez],[Zurück zu Details],[Retour au Détail],[Terug naar Detail],[Voltar Para Detalhes],[詳細に戻る］,[Voltar para Detalhes],[Torna ai dettagli],[Назад к деталям]
-_L_APP_AMIIDB_DETAIL_BACK_LIST,[Back to List],[返回列表],[返回列表],[Volver a Lista],[Vissza a Listához],[Zurück zur Liste],[Retour à la Liste],[Terug naar Lijst].,[Voltar Para a Lista],[リストに戻る］,[Voltar para lista],[Torna alla lista],[Назад к списку]
-_L_APP_AMIIDB_SEARCH_HEAD,Search:,搜索:,搜索:,Buscar:,Keresés:,Suche:,Recherche:,Zoeken:,Pesquisar:,検索する:,Pesquisar,Cerca:,Поиск:
-_L_APP_AMIIDB_MORE,[More...],[更多],[更多],[Más...],[Bővebben...],[Mehr...],[Plus...],[Meer...],[Mais...],[もっと見る...］,[Mais...],[Più...],[Дальше...]
-_L_APP_AMIIDB_MORE_MESSAGE,Too many results. Try a more specific search.,搜索结果过多，尝试增加搜索词。,搜索結果過多，嘗試增加搜索詞。,,,Zu viele Ergebnisse. Bitte Suche eingrenzen.,,,,,,,Очень много совпадений.\nУточните запрос.
-_L_APP_AMIIDB_EMPTY_TAG,<Blank Amiibo>,<空标签>,<空標簽>,<No Asignado>,<Üres Amiibo>,<Leerer Amiibo>,<Amiibo Vierge>,<Blanke Amiibo>,<Amiibo em Branco>,<Amiiboが見つかりません>,<Amiibo vazio>,<Non assegnato>,<пустой тег>
-_L_APP_AMIIDB_SLOT_DELETE,Reset...,重置...,重置...,Borrar...,Újraindítás...,Zurücksetzen...,Réinitialiser...,Reset...,Reiniciar...,リセット...,Reiniciar,Elimina...,Сброс...
-_L_APP_AMIIDB_CONFIRM,Confirm,确认,確認,Confirmar,Megerősítés,Bestätigen,Confirmer,Bevestigen,Confirmar,確認する,Confirmar,Conferma,Да
-_L_APP_AMIIDB_CANCEL,Cancel,取消,取消,Cancelar,Törlés,Abbrechen,Annuler,Annuleren,Cancelar,キャンセルする,Cancelar,Annulla,Отмена
-_L_APP_AMIIDB_TIPS,Confirm,提示,提示,Confirmar,Megerősítés,Bestätigen,Confirmer,Bevestigen,Confirmar,確認する,Confirmar,Conferma,Внимание
-_L_APP_AMIIDB_NEW,New...,新建...,新建...,Nueva...,Új...,Neu...,Nouveau...,Nieuw...,Novo...,新規...,Novo...,Nuovo...,Новая папка...
-_L_APP_AMIIDB_EMPTY,Empty...,清空...,清空...,Vaciar...,Üres...,Leeren...,Vider...,Leeg...,Vazio...,空...,Vazio...,Svuota...,Очистить...
-_L_APP_AMIIDB_DELETE,Delete...,删除...,删除...,Borrar...,Törlés...,Löschen...,Supprimer...,Verwijderen...,Excluir...,削除...,Apagar...,Cancella...,Удалить...
-_L_APP_AMIIDB_FAV_NEW_HEAD,New Fav. Folder:,新建收藏夹:,新建收藏夾:,Nueva Carp. Favoritos:,Új Kedvenc Mappa:,Neuer Fav.-Ordner:,Nouveau Dossier Favori:,Nieuwe Favoriete Map:,Nova Pasta de Favoritos:,新しいお気に入りフォルダ:,Nova pasta favorita:,Nuova cart. preferiti:,Новая папка избранного:
-_L_APP_AMIIDB_FAV_EMPTY_MSG,Empty Fav. Folder?,确认清空收藏夹?,確認清空收藏夾?,¿Vaciar Carp. Favoritos?,Üres Kedvenc Mappa?,Fav.-Ordner leeren?,Vider le Dossier Favori?,Favoriete Map Leegmaken?,Esvaziar Pasta de Favoritos?,お気に入りフォルダを空にしますか？,Limpar pasta de favoritos?,Svuotare cart. preferiti?,Выполнить удаление\n избранного?
-_L_APP_AMIIDB_FAV_DELETE_MSG,Confirm Delete?,确认删除?,確認刪除?,¿Confirma borrado?,Törlés Megerősítése?,Löschen Bestätigen?,Confirmer la Suppression?,Verwijderen Bevestigen?,Confirmar Exclusão?,削除してよろしいですか？,Confirmar eliminação?,Conferma cancellazione?,Выполнить удаление?
-_L_APP_AMIIDB_FAV_SELECT_FOLDER,Select Fav. Folder...,选择收藏夹...,選擇收藏夾...,Selec. carp. favoritos...,Kedvenc Mappa Kiválasztása...,Fav.-Ordner auswählen...,Sélectionner le Dossier Favori...,Selecteer Favoriete Map...,Selecionar Pasta Favorita...,お気に入りフォルダを選択...,Selecionar pasta de favoritos,Selez. cart. preferiti...,Выбрать папку избранного...
-_L_APP_AMIIDB_FAV_SUCCESS,Favorite Success,收藏成功,收藏成功,¡Adicionado a Favoritos!,Kedvenc Sikeres,Favorit erstellt ,Succès du Favori,Favoriet Geslaagd,Favorito Bem-Sucedido,お気に入りに追加されました,Adicionado aos Favoritos,Preferito aggiunto!,Добавлено
-_L_APP_AMIIDB_FAV_FAILED,Favorite Failed!,收藏失败,收藏失敗,¡Fallo al adicionar\na Favoritos!,Kedvenc Sikertelen!,Favorisieren fehlgeschlagen!,Échec du Favori!,Favoriet Mislukt!,Favorito Falhou!,お気に入りに追加できませんでした!,Favorito falhou!,Preferito non aggiunto!,Ошибка добавления
-_L_APP_AMIIDB_SLOT_SAVE_SUCCESS,Save Success,保存成功,保存成功,Asignación correcta,Sikeresen Mentve,Speichern erfolgreich,Sauvegarder Succès,Opslaan Succes,Salvar Com Êxito,保存されました,Guardado com sucesso,Assegnazione corretta,Сохранено
-_L_APP_AMIIDB_SLOT_SAVE_FAILED,Save Failed!,保存失败,保存失敗,¡Asignación fallida!,Mentés Sikertelen!,Speichern fehlgeschlagen!,Sauvegarde Échouée!,Opslaan Mislukt!,Falha ao Salvar!,保存に失敗しました!,Falha ao Guardar!,Assegnazione fallita!,Ошибка сохранения
-_L_APP_CHAMELEON,Card Emulator,卡模拟器,卡模擬器,Emular Etiqueta RFID,Kártya Emulátor,Karten Emulator,Emulateur de Carte,Kaart Emulator,Emulador de Cartão,カードエミュレータ,Emular Tag RFID,Emula tag RFID,Эмулятор карт
-_L_APP_CHAMELEON_TAG_MF1_WRITE_NORMAL,Normal,正常,正常,Normal,Normál,Normal,Normal,Normaal,Normal,通常,Normal,Normale,Разрешена
-_L_APP_CHAMELEON_TAG_MF1_WRITE_DENIED,Deny,拒绝,拒絕,Negar,Tagadni,Verweigern,Refuser,Weigeren,Negar,拒否,Cancelar,Nega,Запрещена
-_L_APP_CHAMELEON_TAG_MF1_WRITE_DECEIVE,Ignore,忽略,忽略,Ignorar,Figyelmen Kívül Hagyni,Ignorieren,Ignorer,Negeren,Ignorar,無視,Ignorar,Ignora,Игнорируется
-_L_APP_CHAMELEON_TAG_MF1_WRITE_SHADOW,Cache,缓存,緩存,Caché,Elrejt,Cache,Cache,Cache,Cache,キャッシュ,Cache,Cache,В кэш
-_L_APP_CHAMELEON_INITIALIZING,Initializing data ...,"初始化, 请稍后...","初始化, 請稍後...",Inicializando ambiente.\nPor favor espere...,Az adatok inicializálása ...,Daten initialisieren...,Initialisation des données ...,Gegevens Initialiseren ...,Inicialização de Dados ...,データの初期化 ...,Inicializando ambiente.\nPor favor espere..,Inizializzazione ambiente.\nPer favore attendi...,Инициализация...
-_L_APP_CHAMELEON_CARD_SLOT,Slot,卡槽,卡槽,Ranura,Cella,Steckplatz,Fente,Slot,Slot,スロット,Ranhura,Slot,Ячейка
-_L_APP_CHAMELEON_CARD_NICK,Nick,卡名,卡名,Apodo,Becenév,Spitzname,Pseudo,Bijnaam,Apelido,ニックネーム,Nick,Nickname,Название
-_L_APP_CHAMELEON_CARD_ID,ID,ID,ID,ID,ID,ID,ID,ID,ID,ID,ID,ID,ID
-_L_APP_CHAMELEON_CARD_TYPE,Type,卡类型,卡類型,Tipo,Típus,Typ,Type de Données,Type,Tipo de Dados,タイプ,Tipo,Tipo,Тип
-_L_APP_CHAMELEON_CARD_DATA,Data...,卡数据...,卡數據...,Datos...,Adatok...,Daten...,Données...,Gegevens...,Dados...,データ...,Dados..,Dati...,Данные...
-_L_APP_CHAMELEON_CARD_ADVANCED,Advanced...,卡高级设置...,卡高級設置...,Avanzado...,Fejlett...,Erweitert...,Avancé...,Geavanceerd...,Avançado...,詳細設定...,Avançado..,Avanzato...,Дополнительно...
-_L_APP_CHAMELEON_CARD_SLOT_SETTINGS,Slots Settings...,卡槽管理...,卡槽管理...,Configuración...,Cella Beállításai...,Steckplatz Einstellungen...,Paramètres des Emplacements...,Slot Instellingen...,Configurações de Slots...,スロット設定...,Definições de Ranhura..,Impostazioni...,Управление ячейками...
-_L_APP_CHAMELEON_CARD_SLOT_NUM,Slot Num...,卡槽数量...,卡槽數量...,Cant. ranuras...,Cella Száma...,Steckplatz Nummer,Numéro d'Emplacement...,Slotnummer...,Número do Slot...,スロット番号...,Ranhura numero...,Num. slot...,Число ячеек...
-_L_APP_CHAMELEON_CARD_SET_NICK_SUCCESS,Set Nick Success,设置卡名成功,設置卡名成功,Apodo cambiado.,Becenév Beállítása Sikeres,Spitzname erfolgreich gesetzt,Définir le Pseudo Succès,Bijnaam Instellen Succes,Apelido Definido com Sucesso,ニックネームが設定されました,Nick definido com sucesso,Cambio nickname riuscito.,Название задано
-_L_APP_CHAMELEON_CARD_SET_NICK_FAILED,Set Nick Failed!,设置卡名失败,設置卡名失敗,¡Falló cambio apodo!,Becenév Beállítása Sikertelen!,Spitzname setzen fehlgeschlagen!,Définir le Pseudo a Échoué!,Bijnaam Instellen Mislukt!,Falha ao Definir Apelido!,ニックネームが設定できませんでした!,Definição do Nick falhou!,Cambio nickname fallito!,Недопустимое название
-_L_APP_CHAMELEON_CARD_INPUT_NICK,Input Nick:,输入卡名:,輸入卡名:,Apodo:,Becenév Bevitele:,Spitznamen eingeben:,Entrer le Pseudo:,Voer Bijnaam In:,Insira o Apelido:,ニックネームを入力してください：,Introduzir Nick,Nickname:,Задайте название карты:
-_L_APP_CHAMELEON_CARD_DATA_LOAD,Load...,加载...,加載...,Cargar...,Betöltés...,Laden...,Charger...,Laden...,Carregar...,ロード...,Carregar..,Carica...,Загрузка...
-_L_APP_CHAMELEON_CARD_DATA_SAVE,Save...,导出...,導出...,Guardar...,Mentés...,Speichern...,Sauvegarder...,Opslaan...,Salvar...,保存...,Guardar..,Salva...,Сохранение...
-_L_APP_CHAMELEON_CARD_DATA_FACTORY,Factory...,重置...,重置...,Inicializar...,Visszaállítás...,Zurücksetzen...,Rétablir Les Valeurs Par Défaut...,Terugzetten Naar Standaard...,Restaurar Padrões...,初期化...,Iniciar..,Inizializza...,Сброс...
-_L_APP_CHAMELEON_CARD_DATA_FACTORY_SUCCESS,Data Factory Success,卡片初始化成功,卡片初始化成功,¡Datos inicializados!,Adatok Visszaállítása Sikeres,Daten zurückgesetzt,Réinitialisation des Données Succès,Fabriekgegeven terugzetten Succesvol,Restauração de Dados Bem-Sucedida,初期化成功,Dados carregados com sucesso,Dati inizializzati!,Данные сброшены
-_L_APP_CHAMELEON_CARD_DATA_LOAD_NOT_FOUND,File Not Found,文件不存在,文件不存在,Archivo no encontrado,Fájl Nem Található,Datei nicht gefunden,Fichier Non Trouvé,Bestand Niet Gevonden,Arquivo Não Encontrado,ファイルが見つかりません,Ficheiro não encontrado,File non trovato,Файл не обнаружен
-_L_APP_CHAMELEON_CARD_DATA_LOAD_SIZE_NOT_MATCH,File Size Not Match,文件大小不匹配,文件大小不匹配,Tamaño archivo incorrecto,Fájl Mérete Nem Egyezik,Dateigröße stimmt nicht überein,La Taille du Fichier ne Correspond Pas,Bestandsgrootte Komt Niet Overeen,Tamanho do Arquivo Não Corresponde,ファイルサイズが一致しません,Tamanho do ficheiro incorreto,Dimensione file non corretta,Файл несоразмерен
-_L_APP_CHAMELEON_CARD_DATA_LOAD_FAILED,Load File Failed,读取文件失败,讀取文件失敗,Falla al cargar archivo,Fájl betöltése Sikertelen,Laden der Datei fehlgeschlagen,Échec du Chargement du Fichier,Bestand Laden Mislukt,Falha no Carregamento do Arquivo,ファイルの読み込み失敗,Falha ao carregar ficheiro,Caricamento file fallito,Ошибка загрузки файла
-_L_APP_CHAMELEON_CARD_DATA_LOAD_SUCCESS,Load File Success,加载卡片数据成功,加載卡片數據成功,Carga archivo correcta,Fájl Betöltése Sikeres,Datei erfolgreich geladen,Chargement du Fichier Réussi,Laad Bestand Succesvol,Sucesso no Carregamento do Arquivo,ファイルの読み込みに成功,Ficheiro carregado com sucesso,Caricamento file riuscito,Данные загружены
-_L_APP_CHAMELEON_CARD_DATA_SAVE_INPUT_FILE_NAME,Input File Name:,输入文件名,輸入文件名,Nombre archivo:,Bemeneti Fájl Neve:,Datei Namen eingeben:,Saisir le Nom du Fichier:,Bestandsnaam Invoeren:,Nome do Arquivo de Entrada:,入力ファイル名:,Nome do Ficheiro:,Nome file:,Задайте имя файла:
-_L_APP_CHAMELEON_CARD_DATA_SAVE_FAILED,Save File Failed!,写入文件失败,寫入文件失敗,¡Error al guardar!,Fájl Mentése Sikertelen!,Datei speichern fehlgeschlagen!,Échec de l'Enregistrement du Fichier!,Bestand Opslaan Mislukt!,Falha ao Salvar o Arquivo!,ファイルの保存に失敗しました！,Erro ao guardar!,Errore nel salvataggio!,Ошибка сохранения файла
-_L_APP_CHAMELEON_CARD_DATA_SAVE_SUCCESS,Save File Success,导出卡片数据成功,導出卡片數據成功,Guardado correcto,Fájl Mentése Sikeres,Datei erfolgreich gespeichert,Sauvegarde du Fichier Réussie,Bestand Opslaan Gelukt,Arquivo Salvo com êxito,ファイルが保存されました,Guardado com sucesso,Salvataggio riuscito,Данные сохранены
-_L_APP_CHAMELEON_CARD_ADV_CUSTOM_MODE,Custom Mode,自定义模式,自定義模式,Modo personali.,Egyéni Mód,Benutzerdefinierter Modus,Mode Personnalisé,Aangepaste Modus,Modo Personalizado,カスタムモード,Modo personalizado,Modalità personalizzata,Заказной режим
-_L_APP_CHAMELEON_CARD_GEN1A_MODE,Gen1A Enabled,Gen1A模式,Gen1A模式,Gen1A habilitada,Gen1A Engedélyezve,Gen1A aktiv,Gen1A Activé,Gen1A Ingeschakeld,Gen1A Ativada,Gen1A 有効,Gen1A ativado,Gen1A abilitata,Gen1A
-_L_APP_CHAMELEON_CARD_GENERATE_UID,Rand. UID,生成UID,生成UID,Generar UID aleat.,Véletlen UID,Zufällige UID,Randomiser l'UID,Willekeurige UID,UID Aleatório,UIDのランダム化,Gerar novo UID,Genera nuovo UID,Сгенерировать UID
-_L_APP_CHAMELEON_CARD_GENERATE_UID_SUCCESS,UID Generated,UID已生成,UID已生成,UID generado,Generált UID,UID generiert,UID Généré,UID Gegenereerd,UID Gerado,UID 生成,UID gerado,UID generato,UID сгенерирован
-_L_APP_CHAMELEON_CARD_GEN2_MODE,Gen2 Enabled,Gen2模式,Gen2模式,Gen2 habilitada,Gen2 Engedélyezve,Gen2 aktiv,Gen2 Activé,Gen2 Ingeschakeld,Gen2 Ativado,Gen2 有効,Gen2 ativado,Gen2 abilitata,Gen2
-_L_APP_CHAMELEON_CARD_WRITE_MODE,Write Mode,写入模式,寫入模式,Modo escrit.,Írási Mód,Schreibmodus,Mode d'Écriture,Schrijfmodus,Modo de Gravação,書き込みモード,Modo escrita,Modalità scrittura,Запись
-_L_APP_CHAMELEON_CARD_ADV_ID_EDIT_INVALID_INPUT,Invalid Input!,无效的输入!,無效的輸入!,¡Entrada inválida!,Érvénytelen bemenet!,Ungültige Eingabe!,Entrée Invalide!,Ongeldige Invoer!,Entrada Inválida!,無効な入力,Texto invalida,Input non valido!,Недопустимый ввод
-_L_APP_CHAMELEON_CARD_TYPE_FACTORY_DATA_CONFRIM,Card type changed. \nFactory card data?,卡类型已修改\n重置卡数据?,卡類型已修改\n重置卡數據?,Tipo tarjeta modificado\n¿Inicializar tarjeta?,A kártya típusa megváltozott.\nGyári kártyaadatok?,Kartentyp geändert. \nKartendaten zurücksetzen?,Le Type de Carte a Été Modifié. \nRéinitialiser les Données de la Carte?,Kaarttype gewijzigd. \nGegevens terugzetten naar standaard?,O tipo de cartão foi alterado. \nRedefinir dados do cartão?,カードの種類が変更されました。\nカードデータを初期化しますか？,Tipo de cartão alterado. \nFormatar cartão?,Tipo di carta modificato\nInizializzare carta?,Тип карты изменен.\nСбросить данные карты?
-_L_APP_CHAMELEON_CARD_DEFAULT_CARD,Default Card,默认卡片,默认卡片,,,,,,,,,,По умолчанию
-_L_APP_GAME,Game,游戏,游戏,,,,,,,,,,Игры
-_L_APP_GAME_TINY_ARKANOID,Arkanoid,打砖块,打磚塊,,,,,,,,,,Арканоид
-_L_APP_GAME_TINY_INVADERS,Invaders,入侵者,入侵者,,,,,,,,,,Космические захватчики
-_L_APP_GAME_TINY_LANDER,Lander,星球着陆,星球著陸,,,,,,,,,,Посадка на Луну
-_L_APP_GAME_TINY_TRIS,Tris,俄罗斯方块,俄羅斯方塊,,,,,,,,,,Тетрис
+CODE,en_US,zh_Hans,zh_TW,es_ES,hu_HU,de_DE,fr_FR,nl_NL,pt_BR,ja_JP,pt_PT,it_IT,ru_RU,ko_KR
+_L_ON,ON,开,開,SI,BE,AN,ACTIVÉ,AAN,LIGADO,オン,SIM,SI,Включено,켜짐
+_L_OFF,OFF,关,關,NO,KI,AUS,DÉSACTIVÉ,UIT,DESLIGADO,オフ,NÃO,NO,Выключено,꺼짐
+_L_ON_F,[ON],[开],[開],[SI],[BE],[AN],[ACTIVÉ],[AAN],[LIGADO],[オン],[SIM],[SI],[Вкл],[켜짐]
+_L_OFF_F,[OFF],[关],[關],[NO],[KI],[AUS],[DÉSACTIVÉ],[UIT],[DESLIGADO],[オフ],[NÃO],[NO],[Выкл],[꺼짐]
+_L_BACK,Back,返回,返回,[Atrás],Vissza,Zurück,Retour,Terug,Voltar,戻る,Voltar,Indietro,[Назад],뒤로
+_L_ERR,Error,错误,錯誤,Error,Hiba,Fehler,Erreur,Fout,Erro,エラー,Erro,Errore,Ошибка,오류
+_L_ERR_CODE,Error Code,错误码,錯誤碼,Código error,Hibakód,Fehlercode,Code d'Erreur,Foutcode,Código de Erro,エラーコード,Código de Erro,Codice errore,Код ошибки,오류코드
+_L_FAILED,Failed,失败,失敗,,,,,,,,,,Ошибка,실패
+_L_APP_AMIIBO,Amiibo Emulator,Amiibo模拟器,Amiibo模擬器,Emulador de amiibo,Amiibo Emulátor,Amiibo Emulator,Emulateur Amiibo,Amiibo-Emulator,Emulador de Amiibo,Amiiboエミュレータ,Emulador de Amiibo,Emulatore Amiibo,Эмулятор Amiibo,아미보 에뮬레이터
+_L_APP_AMIIBOLINK,AmiiboLink,AmiiboLink,AmiiboLink,AmiiboLink,AmiiboLink,AmiiboLink,AmiiboLink,AmiiboLink,AmiiboLink,AmiiboLink,AmiiboLink,AmiiboLink,AmiiboLink,아미보링크
+_L_APP_BLE,BLE File Transfer,蓝牙传输,藍牙傳送,Transferencia BLE,BLE Fájltovábbítás,BLE Dateitransfer,Transfert de Fichiers BLE,BLE Bestandsoverdracht,Transferência de Arquivos BLE,BLEファイル転送,Transferência BLE,Trasferimento file BLE,Передача файлов,BLE 파일 전송
+_L_APP_BLE_TITLE,BLE File Transfer,蓝牙传输,藍牙傳送,Transferencia BLE,BLE Fájltovábbítás,BLE Dateitransfer,Transfert de Fichiers BLE,BLE Bestandsoverdracht,Transferência de Arquivos BLE,BLEファイル転送,Transferência BLE,Trasferimento file BLE,по Bluetooth,BLE 파일 전송
+_L_APP_PLAYER,Video Player,动画播放器,動畫播放器,Reproductor vídeo,Video Lejátszó,Videoplayer,Lecteur Vidéo,Videospeler,Reprodutor de Vídeo,ビデオプレーヤー,Reprodutor de vídeo,Lettore video,Видеоплеер,비디오 플레이어
+_L_APP_SET,Settings,系统设置,系統設定,Configuraciones,Beállítások,Einstellungen,Paramètres,Instellingen,Configurações,設定,Definições,Impostazioni,Настройки,설정
+_L_APP_SET_VERSION,Version,版本,版本,Versión,Verzió,Version,Version,Versie,Versão,バージョン,Versão,Versione,Версия,버전
+_L_APP_SET_STORAGE_USED,Used,已用,已用,Usado,Használt,Belegt,Utilisé,Gebruikt,Usado,使用ストレージ,Usada,Usato,Занято,사용된
+_L_APP_SET_STORAGE,External Storage,外置存储,外置存儲,M. Flash,Külső Tároló,Externer Speicher,Stockage Externe,Externe Opslag,Armazenamento Externo,外部ストレージ,Memoria Externa,Memoria esterna,Накопитель,외부 저장소
+_L_APP_SET_OLED_CONTRAST,Contrast,对比度,對比度,Contraste OLED,Kontraszt,Kontrast,Contraste,Contrast,Contraste do,コントラスト,Contraste,Contrasto,Контрастность,대비
+_L_APP_SET_OLED_CONTRAST_TITLE,Contrast,对比度,對比度,Contraste OLED,Kontraszt,Kontrast,Contraste,Contrast,Contraste do,コントラスト,Contraste,Contrasto,Контраст OLED,대비
+_L_APP_SET_LCD_BACKLIGHT,Backlight,背光亮度,背光亮度,Brillo,Háttérvilágítás,Beleuchtung,Rétroéclairage,Achtergrondverlichting,Luz de Fundo,バックライト,Brilho,Luminosità,Подсветка,백라이트
+_L_APP_SET_LCD_BACKLIGHT_TITLE,Backlight Brightness,背光亮度,背光亮度,Brillo de fondo,Háttérvilágítás Fényerő,Helligkeit,Luminosité du Rétroéclairage,Helderheid Achtergrondverlichting,Brilho da Luz de Fundo,バックライトの明るさ,Brilho do Ecrã,Luminosità schermo,Яркость подсветки,백라이트 밝기
+_L_APP_SET_ANIM,Menu Animation,动画效果,動畫效果,Animar menú,Menü Animáció,Menü Animation,Animation du Menu,Menu-Animatie,Animação do Menu,メニュー アニメーション,Animação do Menu,Animazione menu,Анимация меню,메뉴 에니메이션
+_L_APP_SET_LIPO_BAT,LiPO Battery,LiPO电池,LiPO電池,Batería LiPO,LiPO Akkumulátor,LiPO Batterie,Batterie LiPO,LiPO-Batterij,Bateria LiPO,LiPOバッテリー,Bateria LiPO,Batteria LiPO,Батарея LiPO,LiPO 배터리
+_L_APP_SET_SHOW_MEM_USAGE,Memory Used,内存使用率,記憶體使用率,Estad. Mem.,Használt Memória,Speicheranzeige,Mémoire Utilisée,Gebruikt Geheugen,Memória Usada,使用メモリ,Memoria Usada,Memoria usata,Статус памяти,사용된 메모리
+_L_APP_SET_HIBERNATE,Fast Wakeup,快速唤醒,快速喚醒,Hibernar,Gyors Ébresztés,Schnelles Aufwachen,Réveil Rapide,Snel Ontwaken,Despertar Rápido,高速起動,Suspender,Risveglio rapido,Гибернация,빠른 화면 켜짐
+_L_APP_SET_SLEEP_TIMEOUT,Sleep Timeout,休眠时间,休眠時間,Dormir en:,Alvási Időkorlát,Standby nach,Délai de mise en veille,Time-out Slaapstand,Tempo Limite de Suspensão,スリープタイムアウト,Suspender em:,Timeout di sospensione,Таймаут сна,화면 꺼짐 시간
+_L_APP_SET_LANGUAGE,Language,系统语言,系統語言,Idioma,Nyelv,Sprache,Langue,Taal,Idioma,言語,Idioma,Lingua,Язык,언어
+_L_APP_SET_GO_SLEEP,Go Sleep,进入休眠,進入休眠,,,,,,,,,,В режим сна,바로 꺼짐
+_L_APP_SET_DFU,Firmware Update,固件更新,軟體升級,Actualizar firmware,Firmware Frissítés,Firmw. Aktualisierung,Mise à Jour du Micrologiciel,Firmware Bijwerken,Atualização de Firmware,ファームウェア更新,Atualizações,Aggiornamento firmware,Обновление ПО,펌웨어 업데이트
+_L_APP_SET_REBOOT,System Reboot,重启设备,重啟設備,Reiniciar,Rendszer Újraindítása,System Neustart,Redémarrage du Système,Systeem Herstarten,Reinicialização do Sistema,システム再起動,Reiniciar,Riavvio del sistema,Перезагрузка,시스템 재부팅
+_L_APP_SET_RESET_DEFAULT,Reset Default Setting,重置默认配置,重置默認配置,Restablecer config.,Alapért. Beállítás Visszaállítása,Standardeinstellungen,Rétablir les Paramètres par Défaut,Terugzetten Naar Standaardwaarden,Restaurar Configurações Padrão,デフォルト設定に戻す,Repor Definições,Ripristina impostazioni predefinite,Сброс настроек,기본 설정 되돌리기
+_L_APP_SET_RESET_DEFAULT_SUCCESS,Reset Success!,重置成功,重置成功,¡Configuración Restablecida!,Alapért. Beállítások Visszaállítása,Einstellungen zurückgesetzt!,Réinitialiser les Paramètres Par Défaut,Standaardinstellingen Herstellen,Redefinir a Configuração Padrão,設定を初期化,Reposição Completa!,Ripristino riuscito!,Сброс выполнен,리셋 성공!
+_L_APP_SET_RESET_DEFAULT_CONFIRM,Confirm Reset Settings?,确认重置默认设置？,确认重置默认设置？,¿Confirma Restablecer\nConfig.?,,Auf Standardeinstellungen zurücksetzen?,,,,,,Conferma il ripristino delle impostazioni?,Выполнить?,기본값으로 재설정 하시겠습니까?
+_L_APP_SET_ABOUT,About Device,关于设备,關於設俻,Acerca del dispositivo,,,,,,,,,Об устройстве,장치 소개
+_L_APP_SET_ABOUT_OPEN_SOURCE_PROJECT,Open Source Project,开源项目,開源項目,Poyecto de código abierto,,,,,,,,,Проект с открытым кодом,오픈 소스 프로젝트
+_L_APP_SET_ABOUT_LGPL_LICENSE,GPL 2.0 License,GPL 2.0 授权,GPL 2.0 授權,Licencia GPL 2.0,,,,,,,,,Лицензия GPL 2.0,GPL 2.0 라이선스
+_L_15S,15 Seconds,15秒,15秒,15 segundos,15 sec.,15 Sekunden,15 sec.,15 sec.,15 seg.,15秒,15 segundos,15 secondi,15 секунд,15초
+_L_30S,30 Seconds,30秒,30秒,30 segundos,30 sec.,30 Sekunden,30 sec.,30 sec.,30 seg.,30秒,30 segundos,30 secondi,30 секунд,30초
+_L_45S,45 Seconds,45秒,45秒,45 segundos,45 sec.,45 Sekunden,45 sec.,45 sec.,45 seg.,45秒,45 segundos,45 secondi,45 секунд,45초
+_L_1MIN,1 Minute,1分钟,1分鐘,1 minuto,1 min.,1 Minute,1 min.,1 min.,1 min.,1分,1 minuto,1 minuto,1 минута,1분
+_L_2MIN,2 Minutes,2分钟,2分鐘,2 minutos,2 min.,2 Minuten,2 min.,2 min.,2 min.,2分,2 minutos,2 minuti,2 минуты,2분
+_L_3MIN,3 Minutes,3分钟,3分鐘,3 minutos,3 min.,3 Minuten,3 min.,3 min.,3 min.,3分,3 minutos,3 minuti,3 минуты,3분
+_L_AMIIBO_KEY_UNLOADED,Amiibo Key not loaded,Amiibo Key未加载,Amiibo Key未載入,Sin llave amiibo,Amiibo kulcs nincs betöltve,Amiibo Schlüssel fehlt,Clé Amiibo Non Chargée,Amiibo-Sleutel Niet Geladen,A chave Amiibo não foi carregada,Amiiboキーが読み込まれない,Amiibo Key não encontrada,Chiave Amiibo non caricata,Отсутствует файл ключа,아미보 키가 로드되지 않음
+_L_UPLOAD_KEY_RETAIL_BIN,Upload the file key_retail.bin to the root directory of the storage.,上传文件 key_retail.bin\n到存储根目录下。,上傳檔案 key_retail.bin\n到儲存根目錄下。,Suba el archivo\nkey_retail.bin\nal directorio raíz.,Töltse fel a key_retail.bin fájlt a gyökérkönyvtárába.,Platzieren Sie die Datei key_retail.bin im Hauptverzeichnis des Speichers.,Téléchargez le fichier key_retail.bin dans le répertoire racine du stockage.,Upload het bestand key_retail.bin naar de hoofdmap van de opslag.,Carregue o arquivo key_retail.bin no diretório raiz do armazenamento.,key_retail.binファイルをストレージのルートディレクトリにアップロードする。,Carregue o ficheiro key_retail.bin para a raiz do dispositivo.,Carica il file key_retail.bin nella directory root della memoria.,Поместите key_retail.bin\n в корень накопителя,key_retail.bin 파일을 저장소의 루트 디렉토리에 업로드합니다.
+_L_KNOW,Got it,知道了,知道了,Entendido,Megvan,Verstanden,Compris,Begrepen,Entendi,了解,Confirmado,Ho Capito,[Понятно],알겠다.
+_L_RANDOM_GENERATION,Rand. Tag,随机生成,隨機產生,Nuevo serial aleat.,Véletlengenerátor,Zufällige UUID,Randomiser la Balise,Willekeurige Tag,Randomizar Etiqueta,タグのランダム化,Tag Aleatória,Tag casuale,Сгенерировать UUID,무작위 생성
+_L_AUTO_RANDOM_GENERATION,Auto Rand.,自动随机生成,自動隨機產生,Serial alea. aut,Automat. Véletlengenerátor,Zufällige UUID (Automatisch),Randomisation Automatique,Automatische Randomisatie,Randomização Automática,自動ランダム化,Tag Aleatória Auto.,Casuale automatico,Автогенерация,자동 난수 생성
+_L_SET_CUSTOM_ID,Set Custom ID,自定义 ID,自定義 ID,,,,,,,,,,Заказной ID,사용자 지정 ID 설정
+_L_INPUT_ID,Input ID,输入 ID,输入 ID,,,,,,,,,,Задайте ID,입력 ID
+_L_INAVLID_ID,Invalid ID,无效的 ID,無效的 ID,,,,,,,,,,Недопустимый ID,잘못된 ID
+_L_SHOW_QRCODE,Display QR Code,显示二维码,顯示二維碼,Mostrar QR,QR-kód Megjelenítése,QR Code,Afficher le Code QR,QR-Code Weergeven,Exibir QR Code,QRコード表示,Mostrar código QR,Mostra codice QR,QR-код,QR 코드 표시
+_L_READ_ONLY,Read-only,禁止写入,禁止寫入,,,,,,,,,,Только чтение,읽기 전용
+_L_DELETE_TAG,Delete Tag,删除标签,刪除標籤,Borrar amiibo...,Címke Törlése,Tag löschen,Supprimer la Balise,Tag Verwijderen,Excluir Etiqueta,タグの削除,Apagar Tag,Elimina tag,Удалить тег,태그 삭제
+_L_DELETE_TAG_CONFIRM,Confirm Delete %s ?,确认删除 %s ?,確認刪除 %s ?,¿Borrar %s?,Törlés Megerősítése?,Löschen von %s bestätigen?,Confirmer la Suppression de %s ?,Bevestig Verwijderen %s ?,Confirmar Exclusão de %s ?,%s を削除しますか？,Apagar %s definitivamente?,Conferma eliminazione %s\n?,Удалить %s?,%s 삭제 확인?
+_L_BACK_TO_DETAILS,Back to Tag Details,返回详情,返回詳情,[Detalles amiibo],Vissza a Címke Részletkhez,Zurück zu Tag Details,Retour Aux Détails de L'étiquette,Terug naar Tag Details,Voltar Aos Detalhes da Tag,タグの詳細に戻る,Voltar para detalhes,[Torna ai dettagli del tag],[Назад к деталям],태그 세부 정보로 돌아가기
+_L_BACK_TO_FILE_LIST,Back to File List,返回文件列表,返回檔案清單,[Lista Archivos],Vissza a Fájl Listához,Zurück zur Liste,Retour à La Liste Des Fichiers,Terug naar Bestandslijst,Voltar Para a Lista de Arquivos,ファイル一覧に戻る,Voltar para lista,[Torna alla lista dei file],[Назад к списку],파일 목록으로 돌아가기
+_L_BACK_TO_MAIN_MENU,Back to Main Menu,返回主菜单,返回主選單,[Menú Principal],Vissza a Főmenübe,Hauptmenü,Retour au Menu Principal,Terug naar Hoofdmenu,Voltar ao Menu Principal,メインメニューに戻る,Voltar para menu principal,[Torna al menu principale],[В главное меню],메인 메뉴로 돌아가기
+_L_FORMAT,Format,格式化,格式化,Formatear...,Formátum ,Formatieren,Format,Formatteren,Formatar,フォーマット,Formatar,Formatta...,Отформатировать,포맷
+_L_FORMAT_STORAGE,Format Storage,格式化存储,格式化儲存,Formatear mem. Flash,Formátum Tárolás,Speicher formatieren,Format de Stockage,Opslag Formatteren,Formatar Armazenamento,保存領域フォーマット,Formatar memória,Formatta memoria,Форматирование,포맷 저장
+_L_DELETE_ALL_DATA,This will delete all data. Confirm format?,将删除所有数据。\n确认格式化?,將刪除所有資料。\n確認格式化?,Se borrará todos los\ndatos.,Minden adatot töröl. Formázás megerősítése?,Alle Daten löschen?,Cette opération efface toutes les données. Confirmer le formatage?,Hierdoor worden alle gegevens gewist. Formatteren bevestigen?,Isso excluirá todos os dados. Confirmar a formatação?,これですべてのデータが削除されます。よろしいですか？,Isto vai eliminar todos os dados. Confirmar formtação?,Questo cancellerà tutti i dati.\nConferma la formattazione?,Это удалит все данные.\nВыполнить?,모든 데이터가 삭제됩니다. 포맷 하시겠습니까?
+_L_DELETING_MESSAGE,Formatting ...,格式化中...,格式化中...,Formateando...,Formázás ...,Formatiere...,Formatage ...,Formatteren ...,Formatando ...,書式設定 ...,A Formatar...,Formattazione in corso ...,Форматирование...,포맷하는중
+_L_MESSAGE,Message,提示,提示,Inicializar,Üzenet,Meldung,Message,Bericht,Mensagem,メッセージ,A Iniciar,Messaggio,Сообщение,메세지
+_L_CONFIRM,Confirm,确定,確定,Confirmar,Megerősítés,Bestätigen,Confirmer,Bevestigen,Confirmar,確認,Confirmar,Conferma,Да,확인.
+_L_CANCEL,Cancel,取消,取消,Cancelar,Megszüntet,Abbrechen,Annuler,Annuleren,Cancelar,キャンセル,Cancelar,Annulla,Отмена,취소
+_L_BACK_TO_LIST,Back List,返回列表,返回清單,[Voler a lista],Vissza a Listához,Zurück zur Liste,Retour à La Liste,Terug naar Lijst,Voltar à Lista,バックリスト,Voltar para lista,[Torna alla lista],[Назад к списку],목록으로 돌아가기
+_L_NOT_MOUNTED,Not Mounted,未挂载,未掛載,No montado,Nincs Felszerelve,Speicher nicht eingebunden,Stockage non Monté,Niet Gekoppeld,Não Montado,ストレージがマウントされていません,Não montado,Non montato,==[Не подключён]==,장착되지 않은
+_L_MOUNTED_LFS,===Mounted[LFS]===,===已挂载[LFS]===,===已掛載[LFS]===,===[LFS]Montado===,===Szerelt[LFS]===,===Speicher [LFS]===,===Monté[LFS]===,===Gekoppeld[LFS]===,===Montado[LFS]===,===ストレージマウント[LFS]===,===[LFS]Montado===,===Montato[LFS]===,==Подключён[LFS]==,===장착된[LFS]===
+_L_MOUNTED_FFS,===Mounted[FFS]===,===已挂载[FFS]===,===已掛載[FFS]===,===[FFS]Montado===,===Szerelt[FFS]===,===Speicher [FFS]===,===Monté[FFS]===,===Gekoppeld[FFS]===,===Montado[FFS]===,===ストレージマウント[FFS]===,===[FFS]Montado===,===Montato[FFS]===,==Подключён[FFS]==,===장착된[FFS]===
+_L_TOTAL_SPACE,Total,总空间,總空間,Capacidad,Össz.,Gesamt,Total,Totaal,Total,トータル容量,Total,Totale,Ёмкость,총 공간
+_L_AVAILABLE_SPACE,Free,可用空间,可用空間,Libre,Ingyenes,Frei,Libre,Vrij,Livre,空き容量,Livre,Libero,Свободно,사용 가능한 공간
+_L_NOT_AMIIBO_FILE,This is not Amiibo file,这不是Amiibo文件,這不是Amiibo檔案,Este no es un archivo\namiibo válido,Ez nem Amiibo Fájl,Keine Amiibo Datei,Ce n'est pas un fichier Amiibo,Dit is geen Amiibo-bestand,Este Não é um Arquivo Amiibo,これはAmiiboファイルではありません,Ficheiro amiibo incorreto,Questo non è un file\nAmiibo valido,Этот файл не Amiibo,이것은 아미보 파일이 아닙니다.
+_L_READ_FILE_FAILED,Failed read the file,读取文件失败,讀取檔案失敗,Error al leer archivo,Fájl beolvasása sikerten,Lesen fehlgeschlagen,Échec de la lecture du fichier,Lezen van het bestand is mislukt,Falha na Leitura do Arquivo,ファイルの読み込みに失敗しました,Falha ao ler ficheiro,Errore nella lettura del file,Ошибка чтения файла,파일 읽기 실패
+_L_INPUT_FOLDER_NAME,Input Folder Name:,输入文件夹名:,輸入資料夾名稱:,Nombre carpeta:,Bemeneti Mappa Neve:,Ordnername eingeben:,Nom du Dossier D'entrée:,Naam Invoermap:,Nome da Pasta de Entrada:,入力フォルダ名:,Introduzir nome da pasta:,Nome cartella:,Задайте имя папки:,입력 폴더 이름:
+_L_INPUT_AMIIBO_NAME,Input Amiibo Name:,输入amiibo名:,輸入amiibo名稱:,Nombre amiibo:,Amiibo Neve:,Amiibo Namen eingeben:,Nom de l'Amiibo D'entrée:,Naam Amiibo Invoeren:,Nome do Amiibo de Entrada:,入力Amiibo名:,Introduzir nome do Amiibo:,Nome Amiibo:,Задайте имя Amiibo:,입력 아미보 이름:
+_L_DELETE_FILE,Delete %s ?,删除 %s ?,刪除 %s ?,¿Borrar %s?,Törli a %s fájlt?,%s löschen ?,Supprimer le %s ?,%s verwijderen ?,Excluir %s ?,%s を削除しますか ？,,Eliminare %s ?,Удалить %s?,%s 삭제?
+_L_DELETE,Delete...,删除...,刪除...,Borrar...,Töröl...,Löschen...,Supprimer...,Verwijder...,Excluir...,削除...,Apagar,Elimina...,Удалить...,삭제중...
+_L_TIPS,Confirm,提示,提示,Confirmar,Megerősítés,Bestätigen,Confirmer,Bevestigen,Confirmar,確認する,,Conferma,Внимание,확인
+_L_INPUT_NEW_NAME,Input New Name:,输入新名:,輸入新名稱:,Nuevo nombre:,Új Név Bevitele:,Neuen Namen eingeben:,Nouveau nom D'entrée:,Nieuwe Naam Invoeren:,Novo Nome de Entrada:,新しい名前を入力してください：,Introduzir novo nome:,Nuovo nome:,Задайте новое имя:,새 이름 입력:
+_L_INVALID_INPUT,Invalid Input,无效的输入,無效的輸入,Entrada inválida,Érvénytelen Bemenet,Ungültige Eingabe,Entrée Invalide,Ongeldige Invoer,Entrada Inválida,無効な入力,Entrada inválida,Input non valido,Недопустимый ввод,잘못된 입력
+_L_CREATE_NEW_FOLDER,Create New Folder...,新建文件夹...,新建資料夾...,Crear carpeta...,Új Mappa Létrehozása...,Neuer Ordner...,Créer un Nouveau Dossier...,Nieuwe Map Maken...,Criar Nova Pasta...,新しいフォルダを作成...,Criar nova pasta...,Crea cartella...,Создать новую папку...,새 폴더 만드는 중...
+_L_CREATE_NEW_TAG,Create New Tag...,新建标签...,新建標籤...,Crear amiibo...,Új Címke Létrehozása...,Neuer Tag...,Créer une Nouvelle Étiquette...,Nieuwe Tag Aanmaken...,Criar Nova Tag...,新規タグ作成...,Criar nova Tag...,Crea Amiibo...,Создать новый тег...,새 태그 만드는 중...
+_L_CREATE_NEW_TAG_BATCH,Batch Create New Tag...,批量创建标签...,批量創建標簽...,Crear amiibo en lote...,Kötegelt Új Címke Létrehozása...,Mehrere Tags erstellen...,Créer de Nouvelles Étiquettes Par Lot...,Nieuwe Tags in een Batch Aanmaken...,Criar Novas Tags em Lote...,新規タグの一括作成...,Criar multiplos tags...,Crea Amiibo in serie...,Создать группу тегов...,새 태그 일괄 생성중...
+_L_INPUT_TAG_NUM,Input Tag Number：,输入标签数量:,輸入標簽數量:,¿Cuántos?,Beviteli Címke Száma:,Tag Anzahl eingeben:,Saisir le Numéro de l'Étiquette:,Labelnummer Invoeren:,Número da Tag de Entrada:,タグ番号を入力:,Quantas tags?,Numero di tag：,Задайте число тегов:,태그 번호 입력:
+_L_CREATE_TOO_MANY_NUM,Only max %d tags created in a batch.,一次最多只能创建%d个标签,一次最多只能創建%d個標簽,Sólo se puede crear %d en lote,Max. létrehozható címke egy kötegben %d,Sie können nur maximal %d Tags auf einmal erstellen.,Seulement %d balises maximum créées dans un lot.,Maximum %d tags aangemaakt in een batch.,Somente no máximo %d tags criadas em um lote.,１つのバッチで作成されるタグの数はは最大 %d までです。,O limite de tags é %d.,Numero max di %d tag in serie.,За раз можно создать\n не более %d тегов,한 번에 최대 %d개의 태그만 생성할 수 있습니다.
+_L_CREATING_TAG_BATCH,Creating tag,创建标签,創建標簽,Creando...,Címke létrehozása,Tag erstellen,Création d'une balise,Tag aanmaken,Criando tag,タグの作成,A Criar Tag,Creazione tag,Создание тега,태그 만들기
+_L_CREATING_TAG_FAILED,Create tag %s failed!,写入 %s 标签失败,寫入 %s 標簽失敗,¡Error al crear %s!,Címke létrehozása %s sikertelen!,Erstellen von Tag %s fehlgeschlagen!,La création de la balise %s a échoué!,Aanmaken tag %s mislukt!,Falha ao criar a tag %s!,タグ %s の作成に失敗しました！,Criação de Tag %s falhou!,Creazione tag %s fallita!,Ошибка создания тега %s,태그 %s 생성 실패!
+_L_RENAME,Rename...,重命名...,重新命名...,Renombrar...,Átnevezés...,Umbenennen...,Renommer...,Hernoem...,Renomear...,名前の変更...,Renomear ,Rinomina...,Переименовать...,이름 바꾸는 중...
+_L_OPEN_FOLDER_FAILED,Failed to open folder,打开文件夹失败,開啟資料夾失敗,Fallo al abrir carpeta,Mappa megnyitása sikertelen ,Ordner konnte nicht geöffnet werden,Échec de l'ouverture du dossier,Kan map niet openen,Falha ao abrir a pasta,フォルダを開けませんでした,Falha ao abrir pasta,Errore nell'apertura della cartella,Ошибка открытия папки,폴더를 열지 못했습니다.
+_L_RENAME_FAILED,Failed to rename\nError code,重命名失败,重新命名失敗,Fallo al renombrar\nCódigo de error,Átnevezés Sikertelen\nHibakód,Umbenennen fehlgeschlagen\nFehlercode,Échec du renommage.\nCode d'Erreur,Hernoemen mislukt.\nFoutcode,Falha ao renomear\nCódigo de erro,名前の変更に失敗しました。\nエラーコード,Falha ao renomear\nCódigo de Erro,Errore nella rinomina\nCodice errore,Ошибка переименования,이름 변경 실패\n오류코드
+_L_MAIN_RETURN,[RETURN],[返回],[返回],[Volver],[VISSZA],[Zurück],[RETOUR],[TERUG],[RETORNO],[リターン］,[VOLTAR],[Torna indietro],[Назад],[반환]
+_L_RANDOM_MODE_MANUAL,Randomize (Manual),随机模式(手动),隨機模式(手動),Aleatorio (Manual),Randomizálás (Kézi),Zufällige UUID (Manuell),Randomiser (Manuel),Willekeurig (Handmatig),Randomizar (Manual),ランダム化 (手動),Aleatório (Manual),Casuale (Manuale),Ручная генерация UUID,무작위화(수동)
+_L_RANDOM_MODE_AUTO,Randomize (Auto),随机模式(自动),隨機模式(自動),Aleatorio (Auto.),Randomizálás (Automat.),Zufällige UUID (Automatisch),Randomiser (Automatique),Willekeurig (Automatisch),Randomizar (Automático),ランダム化(自動),Aleatório (Auto),Casuale (Automatico),Автогенерация UUID,랜덤화(자동)
+_L_SEQUENCE_MODE,Sequential mode,按序模式,按序模式,Modo Secuencial,Szekvenciális Mód,Sequentieller Modus,Mode Séquentiel,Sequentiële Modus,Modo Sequencial,シーケンシャルモード,Modo Sequencial,Modo sequenziale,Последовательный,순차 모드
+_L_READ_WRITE_MODE,Read-write mode,读写模式,讀寫模式,Modo Lectura/Escrit.,Olvasás-írás Mód,Lese-Schreibmodus,Mode Lecture-Écriture,Lees-Schrijfmodus,Modo de Leitura e Gravação,読み書きモード,Modo Leitura-Escrita,Modo lettura/scrittura,Чтение-запись,읽기-쓰기 모드
+_L_AMIIBOLINK_V1,V1,V1(历史版本),V1(歷史版本),AmiiboLink V1,V1,V1,V1,V1,V1,V1,V1,V1,V1,V1
+_L_AMIIBOLINK_V2,V2,V2(最新版本),V2(最新版本),AmiiboLink V2,V2,V2,V2,V2,V2,V2,V2,V2,V2,V2
+_L_AMILOOP,AmiLoop,AmiLoop,AmiLoop,AmiLoop,AmiLoop,AmiLoop,AmiLoop,AmiLoop,AmiLoop,AmiLoop,AmiLoop,AmiLoop,AmiLoop,아미루프
+_L_MODE,Mode,模式,模式,Modo,Mód,Modus,Mode,Modus,Modo,モード,Modo,Modalità,Режим,모드
+_L_AUTO_RANDOM,Auto Random.,自动随机,自動隨機,Aleat. autom.,Automat. Randomizálás,Zufällige UUID (Automatisch),Randomisation Automatique,Automatische Randomisatie,Randomização Automática,自動ランダム化,Modo Aleatório Automático,Auto. casuale,Автогенерация,자동 무작위
+_L_COMPATIBLE_MODE,Compati. Mode,兼容模式,相容模式,Compatibil.,Kompatibilis Mód,Kompabilitäts Modus,Mode Compatible,Compatibiliteitsmodus,Modo Compatível,互換モード,Modo Compatibilidade,Mod. Compatibilità,Совместимость,호환성 모드
+_L_TAG_DETAILS,[Tag Details],[标签详情],[標籤詳情],[Volver a Detalles],[Tag Részletek],[Zurück zu Details],[Détails de l'Étiquette],[Tag Details],[Detalhes da Tag],[タグ詳細］,[Voltar a detalhes],[Torna ai dettagli],[Назад к деталям],[태그 세부 정보]
+_L_MAIN_MENU,[Main Menu],[主菜单],[主選單],[Menú Principal],[Főmenü],[Hauptmenü],[Menu Principal],[Hoofdmenu],[Menu Principal],[メインメニュー］,[Menu Principal],[Menu principale],[В главное меню],[메인 메뉴]
+_L_MODE_RANDOM,Rand. (Manual),随机(手动),隨機(手動),Aleat. man.,Random (Kézi),Zufällige UUID (Manuell),Aléatoire (Manuel),Willekeurig (Handmatig),Randomização (Manual),ランダム化（手動）,Aleatório (Manual),Casuale man.,Ручная генерация,랜덤(수동)
+_L_MODE_CYCLE,Sequential,按序,按序,Secuencial,Szekvenciális,Sequentiell,Séquentiel,Sequentieel,Sequencial,シーケンシャル,Sequencia,Sequenziale,Последовательный,순차적
+_L_MODE_NTAG,Read/Write,读写,讀寫,Lect./Escr.,Olvasás/Írás,Lesen/Schreiben,Lecture/Écriture,Lezen/Schrijven,Leitura/gravação,リード/ライト,Leitura/Escrita,Lett./Scritt.,Чтение-запись,읽기/쓰기
+_L_MODE_RANDOM_AUTO_GEN,Rand. (Auto),随机(自动),隨機(自動),Aleat. auto.,Random (Automat.),Zufällig (Auto.),Aléatoire (Automatique),Willekeurig (Automatisch),Randomização (Automática),ランダム化（自動）,Randomização Automática ,Auto. casuale,Автогенерация,랜덤(자동)
+_L_BLANK_TAG,Blank NFC tag,空标签,空標籤,Amiibo no asignado,Üres NFC Címke,Leerer NFC Tag,Étiquette NFC vierge,Lege NFC-tag,Tag NFC em Branco,ブランクNFCタグ,Tag NFC vazia,Amiibo non assegnato,Пустой тег,빈 NFC 태그
+_L_APP_AMIIDB,Amiibo Database,Amiibo数据库,Amiibo數據庫,Base datos amiibo,Amiibo Adatbázis,Amiibo Datenbank,Base de Données Amiibo,Amiibo-Database,Banco de Dados Amiibo,Amiiboデータベース,Base de dados Amiibo,Database Amiibo,База данных Amiibo,아미보 데이터 베이스
+_L_APP_AMMIDB_BROWSER,Browser...,查看...,查看...,Explorar...,Böngésző...,Navigieren...,Naviguer...,Browser...,Navegador...,ブラウザ...,Navegar...,Esplora...,Обозреватель...,브라우저...
+_L_APP_AMIIDB_SEARCH,Search...,搜索...,搜索...,Buscar...,Keresés...,Suche...,Recherche...,Zoeken...,Pesquisar...,検索...,Pesquisar...,Cerca...,Поиск...,검색중...
+_L_APP_AMIIDB_MY_FAVORITES,My Favorites...,我的收藏...,我的收藏...,Mis Favoritos...,Kedvencek...,Meine Favoriten...,Mes Favoris...,Mijn Favorieten...,Meus Favoritos...,お気に入り...,Favoritos...,I miei preferiti...,Моё избранное...,내가 좋아하는것...
+_L_APP_AMIIDB_MY_TAGS,My Amiibo...,我的数据...,我的數據...,Mis amiibo...,Amiiboim...,Meine Amiibo...,Mes Amiibo...,Mijn Amiibo...,Meu Amiibo...,マイAmiibo...,Os meus amiibos...,I miei Amiibo...,Мои Amiibo...,내 아미보...
+_L_APP_AMIIDB_SETTINGS,Settings...,设置...,設置...,Configuraciones...,Beállítások...,Einstellungen...,Paramètres...,Instellingen...,Configurações...,設定...,Definições,Impostazioni...,Настройки...,설정중...
+_L_APP_AMIIDB_EXIT,[Exit],[退出],[退出],[Menú Principal],[Kilépés],[Beenden],[Quitter],[Afsluiten],[Sair],[終了],[Exit],[Menu principale],[Выход],[출구]
+_L_APP_AMIIDB_BACK,[Back],[返回],[返回],[Volver],[Vissza],[Zurück],[Retour],[Terug],[Retornar],[戻る],[Back],[Torna indietro],[Назад],[뒤로]
+_L_APP_AMIIDB_SETTINGS_AMIIBO_KEY,Keys,密钥文件,密鑰文件,Llaves,Kulcsok,Schlüssel,Touches,Toetsen,Teclas,キー,Keys (Chaves),Chiavi,Ключ,키
+_L_APP_AMIIDB_SETTINGS_AMIIBO_KEY_LOADED,Loaded,已加载,已加載,Cargadas,Betöltve,geladen,Chargée,Geladen,Carregado,ロードされました,Carregado,Caricate,Загружен,로드됨
+_L_APP_AMIIDB_SETTINGS_AMIIBO_KEY_NOT_LOADED,NOT Loaded,未加载,未加載,NO cargadas,NINCS betöltve,NICHT geladen,NON Chargée,NIET Geladen,NÃO Carregadas,ロードされていません,NÃO carregado,NON caricate,Отсутствует,로드되지 않음
+_L_APP_AMIIDB_SETTINGS_SLOT_NUM,Slot Num.,数据槽位,數據槽位,Cant. ranuras,Slot Száma,Steckplatzanzahl,Numéro d'Emplacement,Slotnummer,Número do Slot,スロット番号,Slot numero,Num. slot,Число ячеек,슬롯 번호
+_L_APP_AMIIDB_DETAIL_FAVORITE,Favorite...,收藏...,收藏...,Favorito...,Kedvenc...,Favorit...,Favorite...,Favoriet...,Favorito...,お気に入り...,Favorito,Preferito...,В избранное...,제일 좋아하는...
+_L_APP_AMIIDB_DETAIL_SAVE_AS,Save As...,保存为...,保存爲...,Asignar en...,Mentés Másként...,Speichern unter...,Enregistrer Sous...,Opslaan Als...,Salvar como...,名前を付けて保存...,Guardar como..,Assegna a...,Сохранить как...,다른 이름으로 저장...
+_L_APP_AMIIDB_DETAIL_BACK_DETAIL,[Back to Detail],[返回详情],[返回詳情],[Volver a Detalles],[Vissza a Részletekhez],[Zurück zu Details],[Retour au Détail],[Terug naar Detail],[Voltar Para Detalhes],[詳細に戻る］,[Voltar para Detalhes],[Torna ai dettagli],[Назад к деталям],[세부 사항으로 돌아가기]
+_L_APP_AMIIDB_DETAIL_BACK_LIST,[Back to List],[返回列表],[返回列表],[Volver a Lista],[Vissza a Listához],[Zurück zur Liste],[Retour à la Liste],[Terug naar Lijst].,[Voltar Para a Lista],[リストに戻る］,[Voltar para lista],[Torna alla lista],[Назад к списку],[목록으로 돌아가기]
+_L_APP_AMIIDB_SEARCH_HEAD,Search:,搜索:,搜索:,Buscar:,Keresés:,Suche:,Recherche:,Zoeken:,Pesquisar:,検索する:,Pesquisar,Cerca:,Поиск:,검색:
+_L_APP_AMIIDB_MORE,[More...],[更多],[更多],[Más...],[Bővebben...],[Mehr...],[Plus...],[Meer...],[Mais...],[もっと見る...］,[Mais...],[Più...],[Дальше...],[더보기...]
+_L_APP_AMIIDB_MORE_MESSAGE,Too many results. Try a more specific search.,搜索结果过多，尝试增加搜索词。,搜索結果過多，嘗試增加搜索詞。,,,Zu viele Ergebnisse. Bitte Suche eingrenzen.,,,,,,,Очень много совпадений.\nУточните запрос.,결과가 너무 많습니다. 더 구체적인 검색을 시도해 보세요.
+_L_APP_AMIIDB_EMPTY_TAG,<Blank Amiibo>,<空标签>,<空標簽>,<No Asignado>,<Üres Amiibo>,<Leerer Amiibo>,<Amiibo Vierge>,<Blanke Amiibo>,<Amiibo em Branco>,<Amiiboが見つかりません>,<Amiibo vazio>,<Non assegnato>,<пустой тег>,<빈 아미보>
+_L_APP_AMIIDB_SLOT_DELETE,Reset...,重置...,重置...,Borrar...,Újraindítás...,Zurücksetzen...,Réinitialiser...,Reset...,Reiniciar...,リセット...,Reiniciar,Elimina...,Сброс...,리셋...
+_L_APP_AMIIDB_CONFIRM,Confirm,确认,確認,Confirmar,Megerősítés,Bestätigen,Confirmer,Bevestigen,Confirmar,確認する,Confirmar,Conferma,Да,확인
+_L_APP_AMIIDB_CANCEL,Cancel,取消,取消,Cancelar,Törlés,Abbrechen,Annuler,Annuleren,Cancelar,キャンセルする,Cancelar,Annulla,Отмена,취소
+_L_APP_AMIIDB_TIPS,Confirm,提示,提示,Confirmar,Megerősítés,Bestätigen,Confirmer,Bevestigen,Confirmar,確認する,Confirmar,Conferma,Внимание,확인
+_L_APP_AMIIDB_NEW,New...,新建...,新建...,Nueva...,Új...,Neu...,Nouveau...,Nieuw...,Novo...,新規...,Novo...,Nuovo...,Новая папка...,새로운...
+_L_APP_AMIIDB_EMPTY,Empty...,清空...,清空...,Vaciar...,Üres...,Leeren...,Vider...,Leeg...,Vazio...,空...,Vazio...,Svuota...,Очистить...,비어있음...
+_L_APP_AMIIDB_DELETE,Delete...,删除...,删除...,Borrar...,Törlés...,Löschen...,Supprimer...,Verwijderen...,Excluir...,削除...,Apagar...,Cancella...,Удалить...,삭제...
+_L_APP_AMIIDB_FAV_NEW_HEAD,New Fav. Folder:,新建收藏夹:,新建收藏夾:,Nueva Carp. Favoritos:,Új Kedvenc Mappa:,Neuer Fav.-Ordner:,Nouveau Dossier Favori:,Nieuwe Favoriete Map:,Nova Pasta de Favoritos:,新しいお気に入りフォルダ:,Nova pasta favorita:,Nuova cart. preferiti:,Новая папка избранного:,새 즐겨찾기 폴더:
+_L_APP_AMIIDB_FAV_EMPTY_MSG,Empty Fav. Folder?,确认清空收藏夹?,確認清空收藏夾?,¿Vaciar Carp. Favoritos?,Üres Kedvenc Mappa?,Fav.-Ordner leeren?,Vider le Dossier Favori?,Favoriete Map Leegmaken?,Esvaziar Pasta de Favoritos?,お気に入りフォルダを空にしますか？,Limpar pasta de favoritos?,Svuotare cart. preferiti?,Выполнить удаление\n избранного?,즐겨찾기 폴더를 지우시겠습니까?
+_L_APP_AMIIDB_FAV_DELETE_MSG,Confirm Delete?,确认删除?,確認刪除?,¿Confirma borrado?,Törlés Megerősítése?,Löschen Bestätigen?,Confirmer la Suppression?,Verwijderen Bevestigen?,Confirmar Exclusão?,削除してよろしいですか？,Confirmar eliminação?,Conferma cancellazione?,Выполнить удаление?,삭제하시겠습니까?
+_L_APP_AMIIDB_FAV_SELECT_FOLDER,Select Fav. Folder...,选择收藏夹...,選擇收藏夾...,Selec. carp. favoritos...,Kedvenc Mappa Kiválasztása...,Fav.-Ordner auswählen...,Sélectionner le Dossier Favori...,Selecteer Favoriete Map...,Selecionar Pasta Favorita...,お気に入りフォルダを選択...,Selecionar pasta de favoritos,Selez. cart. preferiti...,Выбрать папку избранного...,즐겨찾기 폴더 선택...
+_L_APP_AMIIDB_FAV_SUCCESS,Favorite Success,收藏成功,收藏成功,¡Adicionado a Favoritos!,Kedvenc Sikeres,Favorit erstellt ,Succès du Favori,Favoriet Geslaagd,Favorito Bem-Sucedido,お気に入りに追加されました,Adicionado aos Favoritos,Preferito aggiunto!,Добавлено,즐겨찾기에 추가됨
+_L_APP_AMIIDB_FAV_FAILED,Favorite Failed!,收藏失败,收藏失敗,¡Fallo al adicionar\na Favoritos!,Kedvenc Sikertelen!,Favorisieren fehlgeschlagen!,Échec du Favori!,Favoriet Mislukt!,Favorito Falhou!,お気に入りに追加できませんでした!,Favorito falhou!,Preferito non aggiunto!,Ошибка добавления,즐겨 찾기에 추가 할 수 없습니다!
+_L_APP_AMIIDB_SLOT_SAVE_SUCCESS,Save Success,保存成功,保存成功,Asignación correcta,Sikeresen Mentve,Speichern erfolgreich,Sauvegarder Succès,Opslaan Succes,Salvar Com Êxito,保存されました,Guardado com sucesso,Assegnazione corretta,Сохранено,저장됨
+_L_APP_AMIIDB_SLOT_SAVE_FAILED,Save Failed!,保存失败,保存失敗,¡Asignación fallida!,Mentés Sikertelen!,Speichern fehlgeschlagen!,Sauvegarde Échouée!,Opslaan Mislukt!,Falha ao Salvar!,保存に失敗しました!,Falha ao Guardar!,Assegnazione fallita!,Ошибка сохранения,저장 실패!
+_L_APP_CHAMELEON,Card Emulator,卡模拟器,卡模擬器,Emular Etiqueta RFID,Kártya Emulátor,Karten Emulator,Emulateur de Carte,Kaart Emulator,Emulador de Cartão,カードエミュレータ,Emular Tag RFID,Emula tag RFID,Эмулятор карт,카드 에뮬레이터
+_L_APP_CHAMELEON_TAG_MF1_WRITE_NORMAL,Normal,正常,正常,Normal,Normál,Normal,Normal,Normaal,Normal,通常,Normal,Normale,Разрешена,보통
+_L_APP_CHAMELEON_TAG_MF1_WRITE_DENIED,Deny,拒绝,拒絕,Negar,Tagadni,Verweigern,Refuser,Weigeren,Negar,拒否,Cancelar,Nega,Запрещена,거부
+_L_APP_CHAMELEON_TAG_MF1_WRITE_DECEIVE,Ignore,忽略,忽略,Ignorar,Figyelmen Kívül Hagyni,Ignorieren,Ignorer,Negeren,Ignorar,無視,Ignorar,Ignora,Игнорируется,무시
+_L_APP_CHAMELEON_TAG_MF1_WRITE_SHADOW,Cache,缓存,緩存,Caché,Elrejt,Cache,Cache,Cache,Cache,キャッシュ,Cache,Cache,В кэш,캐시
+_L_APP_CHAMELEON_INITIALIZING,Initializing data ...,"初始化, 请稍后...","初始化, 請稍後...",Inicializando ambiente.\nPor favor espere...,Az adatok inicializálása ...,Daten initialisieren...,Initialisation des données ...,Gegevens Initialiseren ...,Inicialização de Dados ...,データの初期化 ...,Inicializando ambiente.\nPor favor espere..,Inizializzazione ambiente.\nPer favore attendi...,Инициализация...,데이터 초기화 중...
+_L_APP_CHAMELEON_CARD_SLOT,Slot,卡槽,卡槽,Ranura,Cella,Steckplatz,Fente,Slot,Slot,スロット,Ranhura,Slot,Ячейка,슬롯
+_L_APP_CHAMELEON_CARD_NICK,Nick,卡名,卡名,Apodo,Becenév,Spitzname,Pseudo,Bijnaam,Apelido,ニックネーム,Nick,Nickname,Название,닉
+_L_APP_CHAMELEON_CARD_ID,ID,ID,ID,ID,ID,ID,ID,ID,ID,ID,ID,ID,ID,ID
+_L_APP_CHAMELEON_CARD_TYPE,Type,卡类型,卡類型,Tipo,Típus,Typ,Type de Données,Type,Tipo de Dados,タイプ,Tipo,Tipo,Тип,유형
+_L_APP_CHAMELEON_CARD_DATA,Data...,卡数据...,卡數據...,Datos...,Adatok...,Daten...,Données...,Gegevens...,Dados...,データ...,Dados..,Dati...,Данные...,데이터...
+_L_APP_CHAMELEON_CARD_ADVANCED,Advanced...,卡高级设置...,卡高級設置...,Avanzado...,Fejlett...,Erweitert...,Avancé...,Geavanceerd...,Avançado...,詳細設定...,Avançado..,Avanzato...,Дополнительно...,고급...
+_L_APP_CHAMELEON_CARD_SLOT_SETTINGS,Slots Settings...,卡槽管理...,卡槽管理...,Configuración...,Cella Beállításai...,Steckplatz Einstellungen...,Paramètres des Emplacements...,Slot Instellingen...,Configurações de Slots...,スロット設定...,Definições de Ranhura..,Impostazioni...,Управление ячейками...,슬롯설정...
+_L_APP_CHAMELEON_CARD_SLOT_NUM,Slot Num...,卡槽数量...,卡槽數量...,Cant. ranuras...,Cella Száma...,Steckplatz Nummer,Numéro d'Emplacement...,Slotnummer...,Número do Slot...,スロット番号...,Ranhura numero...,Num. slot...,Число ячеек...,슬롯번호...
+_L_APP_CHAMELEON_CARD_SET_NICK_SUCCESS,Set Nick Success,设置卡名成功,設置卡名成功,Apodo cambiado.,Becenév Beállítása Sikeres,Spitzname erfolgreich gesetzt,Définir le Pseudo Succès,Bijnaam Instellen Succes,Apelido Definido com Sucesso,ニックネームが設定されました,Nick definido com sucesso,Cambio nickname riuscito.,Название задано,닉 설정 성공
+_L_APP_CHAMELEON_CARD_SET_NICK_FAILED,Set Nick Failed!,设置卡名失败,設置卡名失敗,¡Falló cambio apodo!,Becenév Beállítása Sikertelen!,Spitzname setzen fehlgeschlagen!,Définir le Pseudo a Échoué!,Bijnaam Instellen Mislukt!,Falha ao Definir Apelido!,ニックネームが設定できませんでした!,Definição do Nick falhou!,Cambio nickname fallito!,Недопустимое название,닉 설정 실패!
+_L_APP_CHAMELEON_CARD_INPUT_NICK,Input Nick:,输入卡名:,輸入卡名:,Apodo:,Becenév Bevitele:,Spitznamen eingeben:,Entrer le Pseudo:,Voer Bijnaam In:,Insira o Apelido:,ニックネームを入力してください：,Introduzir Nick,Nickname:,Задайте название карты:,닉네임 입력:
+_L_APP_CHAMELEON_CARD_DATA_LOAD,Load...,加载...,加載...,Cargar...,Betöltés...,Laden...,Charger...,Laden...,Carregar...,ロード...,Carregar..,Carica...,Загрузка...,불러오는중...
+_L_APP_CHAMELEON_CARD_DATA_SAVE,Save...,导出...,導出...,Guardar...,Mentés...,Speichern...,Sauvegarder...,Opslaan...,Salvar...,保存...,Guardar..,Salva...,Сохранение...,저장중...
+_L_APP_CHAMELEON_CARD_DATA_FACTORY,Factory...,重置...,重置...,Inicializar...,Visszaállítás...,Zurücksetzen...,Rétablir Les Valeurs Par Défaut...,Terugzetten Naar Standaard...,Restaurar Padrões...,初期化...,Iniciar..,Inizializza...,Сброс...,초기화...
+_L_APP_CHAMELEON_CARD_DATA_FACTORY_SUCCESS,Data Factory Success,卡片初始化成功,卡片初始化成功,¡Datos inicializados!,Adatok Visszaállítása Sikeres,Daten zurückgesetzt,Réinitialisation des Données Succès,Fabriekgegeven terugzetten Succesvol,Restauração de Dados Bem-Sucedida,初期化成功,Dados carregados com sucesso,Dati inizializzati!,Данные сброшены,초기화 성공
+_L_APP_CHAMELEON_CARD_DATA_LOAD_NOT_FOUND,File Not Found,文件不存在,文件不存在,Archivo no encontrado,Fájl Nem Található,Datei nicht gefunden,Fichier Non Trouvé,Bestand Niet Gevonden,Arquivo Não Encontrado,ファイルが見つかりません,Ficheiro não encontrado,File non trovato,Файл не обнаружен,파일을 찾을 수 없음
+_L_APP_CHAMELEON_CARD_DATA_LOAD_SIZE_NOT_MATCH,File Size Not Match,文件大小不匹配,文件大小不匹配,Tamaño archivo incorrecto,Fájl Mérete Nem Egyezik,Dateigröße stimmt nicht überein,La Taille du Fichier ne Correspond Pas,Bestandsgrootte Komt Niet Overeen,Tamanho do Arquivo Não Corresponde,ファイルサイズが一致しません,Tamanho do ficheiro incorreto,Dimensione file non corretta,Файл несоразмерен,파일 크기가 일치하지 않음
+_L_APP_CHAMELEON_CARD_DATA_LOAD_FAILED,Load File Failed,读取文件失败,讀取文件失敗,Falla al cargar archivo,Fájl betöltése Sikertelen,Laden der Datei fehlgeschlagen,Échec du Chargement du Fichier,Bestand Laden Mislukt,Falha no Carregamento do Arquivo,ファイルの読み込み失敗,Falha ao carregar ficheiro,Caricamento file fallito,Ошибка загрузки файла,파일 로드 실패
+_L_APP_CHAMELEON_CARD_DATA_LOAD_SUCCESS,Load File Success,加载卡片数据成功,加載卡片數據成功,Carga archivo correcta,Fájl Betöltése Sikeres,Datei erfolgreich geladen,Chargement du Fichier Réussi,Laad Bestand Succesvol,Sucesso no Carregamento do Arquivo,ファイルの読み込みに成功,Ficheiro carregado com sucesso,Caricamento file riuscito,Данные загружены,파일 로드 성공
+_L_APP_CHAMELEON_CARD_DATA_SAVE_INPUT_FILE_NAME,Input File Name:,输入文件名,輸入文件名,Nombre archivo:,Bemeneti Fájl Neve:,Datei Namen eingeben:,Saisir le Nom du Fichier:,Bestandsnaam Invoeren:,Nome do Arquivo de Entrada:,入力ファイル名:,Nome do Ficheiro:,Nome file:,Задайте имя файла:,입력 파일 이름:
+_L_APP_CHAMELEON_CARD_DATA_SAVE_FAILED,Save File Failed!,写入文件失败,寫入文件失敗,¡Error al guardar!,Fájl Mentése Sikertelen!,Datei speichern fehlgeschlagen!,Échec de l'Enregistrement du Fichier!,Bestand Opslaan Mislukt!,Falha ao Salvar o Arquivo!,ファイルの保存に失敗しました！,Erro ao guardar!,Errore nel salvataggio!,Ошибка сохранения файла,파일 저장 실패!
+_L_APP_CHAMELEON_CARD_DATA_SAVE_SUCCESS,Save File Success,导出卡片数据成功,導出卡片數據成功,Guardado correcto,Fájl Mentése Sikeres,Datei erfolgreich gespeichert,Sauvegarde du Fichier Réussie,Bestand Opslaan Gelukt,Arquivo Salvo com êxito,ファイルが保存されました,Guardado com sucesso,Salvataggio riuscito,Данные сохранены,파일 저장 성공
+_L_APP_CHAMELEON_CARD_ADV_CUSTOM_MODE,Custom Mode,自定义模式,自定義模式,Modo personali.,Egyéni Mód,Benutzerdefinierter Modus,Mode Personnalisé,Aangepaste Modus,Modo Personalizado,カスタムモード,Modo personalizado,Modalità personalizzata,Заказной режим,사용자 지정 모드
+_L_APP_CHAMELEON_CARD_GEN1A_MODE,Gen1A Enabled,Gen1A模式,Gen1A模式,Gen1A habilitada,Gen1A Engedélyezve,Gen1A aktiv,Gen1A Activé,Gen1A Ingeschakeld,Gen1A Ativada,Gen1A 有効,Gen1A ativado,Gen1A abilitata,Gen1A,Gen1A 활성화
+_L_APP_CHAMELEON_CARD_GENERATE_UID,Rand. UID,生成UID,生成UID,Generar UID aleat.,Véletlen UID,Zufällige UID,Randomiser l'UID,Willekeurige UID,UID Aleatório,UIDのランダム化,Gerar novo UID,Genera nuovo UID,Сгенерировать UID,랜덤 UID
+_L_APP_CHAMELEON_CARD_GENERATE_UID_SUCCESS,UID Generated,UID已生成,UID已生成,UID generado,Generált UID,UID generiert,UID Généré,UID Gegenereerd,UID Gerado,UID 生成,UID gerado,UID generato,UID сгенерирован,UID 생성
+_L_APP_CHAMELEON_CARD_GEN2_MODE,Gen2 Enabled,Gen2模式,Gen2模式,Gen2 habilitada,Gen2 Engedélyezve,Gen2 aktiv,Gen2 Activé,Gen2 Ingeschakeld,Gen2 Ativado,Gen2 有効,Gen2 ativado,Gen2 abilitata,Gen2,Gen2 활성화
+_L_APP_CHAMELEON_CARD_WRITE_MODE,Write Mode,写入模式,寫入模式,Modo escrit.,Írási Mód,Schreibmodus,Mode d'Écriture,Schrijfmodus,Modo de Gravação,書き込みモード,Modo escrita,Modalità scrittura,Запись,쓰기 모드
+_L_APP_CHAMELEON_CARD_ADV_ID_EDIT_INVALID_INPUT,Invalid Input!,无效的输入!,無效的輸入!,¡Entrada inválida!,Érvénytelen bemenet!,Ungültige Eingabe!,Entrée Invalide!,Ongeldige Invoer!,Entrada Inválida!,無効な入力,Texto invalida,Input non valido!,Недопустимый ввод,잘못된 입력
+_L_APP_CHAMELEON_CARD_TYPE_FACTORY_DATA_CONFRIM,Card type changed. \nFactory card data?,卡类型已修改\n重置卡数据?,卡類型已修改\n重置卡數據?,Tipo tarjeta modificado\n¿Inicializar tarjeta?,A kártya típusa megváltozott.\nGyári kártyaadatok?,Kartentyp geändert. \nKartendaten zurücksetzen?,Le Type de Carte a Été Modifié. \nRéinitialiser les Données de la Carte?,Kaarttype gewijzigd. \nGegevens terugzetten naar standaard?,O tipo de cartão foi alterado. \nRedefinir dados do cartão?,カードの種類が変更されました。\nカードデータを初期化しますか？,Tipo de cartão alterado. \nFormatar cartão?,Tipo di carta modificato\nInizializzare carta?,Тип карты изменен.\nСбросить данные карты?,카드 종류가 변경되었습니다. \n카드 데이터를 초기화하시겠습니까?
+_L_APP_CHAMELEON_CARD_DEFAULT_CARD,Default Card,默认卡片,默认卡片,,,,,,,,,,По умолчанию,기본 카드
+_L_APP_GAME,Game,游戏,游戏,,,,,,,,,,Игры,게임
+_L_APP_GAME_TINY_ARKANOID,Arkanoid,打砖块,打磚塊,,,,,,,,,,Арканоид,벽돌깨기
+_L_APP_GAME_TINY_INVADERS,Invaders,入侵者,入侵者,,,,,,,,,,Космические захватчики,슈팅게임
+_L_APP_GAME_TINY_LANDER,Lander,星球着陆,星球著陸,,,,,,,,,,Посадка на Луну,비행기 착륙 게임
+_L_APP_GAME_TINY_TRIS,Tris,俄罗斯方块,俄羅斯方塊,,,,,,,,,,Тетрис,테트리스


### PR DESCRIPTION
Translated untranslated fields in the i18n.csv file to Korean.
This improves accessibility and usability for Korean-speaking users.
