### PR TITLE
fix: amiibolink button event trigger multiple times

### DIFF
--- a/fw/application/src/app/amiibolink/view/amiibolink_view.c
+++ b/fw/application/src/app/amiibolink/view/amiibolink_view.c
@@ -94,6 +94,9 @@ static void amiibolink_view_on_draw(mui_view_t *p_view, mui_canvas_t *p_canvas) 
 
 static void amiibolink_view_on_input(mui_view_t *p_view, mui_input_event_t *event) {
     amiibolink_view_t *p_amiibolink_view = p_view->user_data;
+    if(event->type != INPUT_TYPE_SHORT){
+        return;
+    }
     if(event->key == INPUT_KEY_CENTER){
         if (p_amiibolink_view->event_cb) {
             p_amiibolink_view->event_cb(AMIIBOLINK_VIEW_EVENT_MENU, p_amiibolink_view);


### PR DESCRIPTION
amiibolink app,进入主菜单时按确认键会触发多次, 表现为在标签主页面按确认会连续进入主菜单页面和模式切换界面.