### PR TITLE
feat: add ISO 14443-4 (ISO-DEP) support to card emulator

### DIFF
--- a/fw/application/src/app/chameleon/app_chameleon.h
+++ b/fw/application/src/app/chameleon/app_chameleon.h
@@ -13,6 +13,7 @@ typedef enum {
     APP_CHAMELEON_ID_EDIT_TYPE_UID,
     APP_CHAMELEON_ID_EDIT_TYPE_SAK,
     APP_CHAMELEON_ID_EDIT_TYPE_ATQA,
+    APP_CHAMELEON_ID_EDIT_TYPE_ATS,
 } app_chameleon_id_edit_type_t;
 
 typedef struct {

--- a/fw/application/src/app/chameleon/scene/chameleon_scene_menu_card_advanced.c
+++ b/fw/application/src/app/chameleon/scene/chameleon_scene_menu_card_advanced.c
@@ -21,6 +21,7 @@ typedef enum {
     CHAMELEON_MENU_UID,
     CHAMELEON_MENU_SAK,
     CHAMELEON_MENU_ATQA,
+    CHAMELEON_MENU_ATS,
     CHAMELEON_MENU_GEN1A,
     CHAMELEON_MENU_GEN2,
     CHAMELEON_MENU_GEN_UID,
@@ -74,6 +75,13 @@ void chameleon_scene_menu_card_advanced_on_event(mui_list_view_event_t event, mu
     case CHAMELEON_MENU_ATQA: {
         if (!nfc_tag_mf1_is_use_mf1_coll_res()) {
             app->id_edit_type = APP_CHAMELEON_ID_EDIT_TYPE_ATQA;
+            mui_scene_dispatcher_next_scene(app->p_scene_dispatcher, CHAMELEON_SCENE_MENU_CARD_ADVANCED_ID_EDIT);
+        }
+    } break;
+
+    case CHAMELEON_MENU_ATS: {
+        if (!nfc_tag_mf1_is_use_mf1_coll_res()) {
+            app->id_edit_type = APP_CHAMELEON_ID_EDIT_TYPE_ATS;
             mui_scene_dispatcher_next_scene(app->p_scene_dispatcher, CHAMELEON_SCENE_MENU_CARD_ADVANCED_ID_EDIT);
         }
     } break;
@@ -142,6 +150,15 @@ void chameleon_scene_menu_card_advanced_reload(app_chameleon_t *app) {
 
     sprintf(buff, "[%02X %02X]", coll_res->atqa[1], coll_res->atqa[0]);
     mui_list_view_add_item_ext(app->p_list_view, ICON_FILE, "ATQA", buff, CHAMELEON_MENU_ATQA);
+
+    if (coll_res->ats->length > 0) {
+        sprintf(buff, "[%d B]", coll_res->ats->length);
+    } else if (coll_res->sak[0] & 0x20) {
+        sprintf(buff, "[auto]");
+    } else {
+        sprintf(buff, "[-]");
+    }
+    mui_list_view_add_item_ext(app->p_list_view, ICON_FILE, "ATS", buff, CHAMELEON_MENU_ATS);
 
     if (tag_group == TAG_GROUP_MIFARE) {
         mui_list_view_add_item_ext(app->p_list_view, ICON_PAGE, _T(APP_CHAMELEON_CARD_GEN1A_MODE),

--- a/fw/application/src/app/chameleon/scene/chameleon_scene_menu_card_advanced_id_edit.c
+++ b/fw/application/src/app/chameleon/scene/chameleon_scene_menu_card_advanced_id_edit.c
@@ -16,6 +16,10 @@
 
 #include "fds_utils.h"
 
+#include <ctype.h>
+
+#define ATS_MAX_LENGTH 16
+
 typedef enum {
     CHAMELEON_MENU_BACK,
     CHAMELEON_MENU_FILE,
@@ -68,8 +72,10 @@ static void format_id_edit_text(app_chameleon_id_edit_type_t id_edit_type, char 
 
     case APP_CHAMELEON_ID_EDIT_TYPE_ATS:
         if (coll_res->ats->length > 0) {
+            uint8_t len = coll_res->ats->length;
+            if (len > ATS_MAX_LENGTH) len = ATS_MAX_LENGTH;
             char *p = text;
-            for (uint8_t i = 0; i < coll_res->ats->length && i < 10; i++) {
+            for (uint8_t i = 0; i < len; i++) {
                 if (i > 0) *p++ = '.';
                 sprintf(p, "%02x", coll_res->ats->data[i]);
                 p += 2;
@@ -147,23 +153,27 @@ static bool handle_id_edit_cb(app_chameleon_t *app, const char *text) {
             coll_res->ats->length = 0;
             return true;
         }
-        // Parse dot-separated hex bytes
-        uint8_t ats_data[16];
+        uint8_t ats_data[ATS_MAX_LENGTH];
         uint8_t ats_len = 0;
         const char *p = text;
-        while (*p && ats_len < sizeof(ats_data)) {
-            int val;
-            if (sscanf(p, "%02x", &val) != 1) break;
+        while (*p) {
+            if (ats_len >= ATS_MAX_LENGTH) return false;
+            if (!isxdigit((unsigned char)p[0]) || !isxdigit((unsigned char)p[1])) return false;
+            unsigned int val;
+            if (sscanf(p, "%2x", &val) != 1) return false;
             ats_data[ats_len++] = (uint8_t)val;
             p += 2;
-            if (*p == '.') p++;
+            if (*p == '.') {
+                p++;
+                if (*p == '\0') return false;
+            } else if (*p != '\0') {
+                return false;
+            }
         }
-        if (ats_len > 0) {
-            memcpy(coll_res->ats->data, ats_data, ats_len);
-            coll_res->ats->length = ats_len;
-            return true;
-        }
-        break;
+        if (ats_len == 0) return false;
+        memcpy(coll_res->ats->data, ats_data, ats_len);
+        coll_res->ats->length = ats_len;
+        return true;
     }
     }
 

--- a/fw/application/src/app/chameleon/scene/chameleon_scene_menu_card_advanced_id_edit.c
+++ b/fw/application/src/app/chameleon/scene/chameleon_scene_menu_card_advanced_id_edit.c
@@ -32,6 +32,9 @@ static const char *get_id_edit_title(app_chameleon_id_edit_type_t id_edit_type) 
     case APP_CHAMELEON_ID_EDIT_TYPE_ATQA:
         return "ATQA:";
 
+    case APP_CHAMELEON_ID_EDIT_TYPE_ATS:
+        return "ATS:";
+
     default:
         return "";
     }
@@ -61,6 +64,19 @@ static void format_id_edit_text(app_chameleon_id_edit_type_t id_edit_type, char 
 
     case APP_CHAMELEON_ID_EDIT_TYPE_ATQA:
         sprintf(text, "%02x.%02x", coll_res->atqa[1], coll_res->atqa[0]);
+        return;
+
+    case APP_CHAMELEON_ID_EDIT_TYPE_ATS:
+        if (coll_res->ats->length > 0) {
+            char *p = text;
+            for (uint8_t i = 0; i < coll_res->ats->length && i < 10; i++) {
+                if (i > 0) *p++ = '.';
+                sprintf(p, "%02x", coll_res->ats->data[i]);
+                p += 2;
+            }
+        } else {
+            text[0] = '\0';
+        }
         return;
     }
 }
@@ -124,6 +140,31 @@ static bool handle_id_edit_cb(app_chameleon_t *app, const char *text) {
             return true;
         }
         break;
+
+    case APP_CHAMELEON_ID_EDIT_TYPE_ATS: {
+        if (strlen(text) == 0) {
+            // Empty input clears ATS (reverts to auto mode)
+            coll_res->ats->length = 0;
+            return true;
+        }
+        // Parse dot-separated hex bytes
+        uint8_t ats_data[16];
+        uint8_t ats_len = 0;
+        const char *p = text;
+        while (*p && ats_len < sizeof(ats_data)) {
+            int val;
+            if (sscanf(p, "%02x", &val) != 1) break;
+            ats_data[ats_len++] = (uint8_t)val;
+            p += 2;
+            if (*p == '.') p++;
+        }
+        if (ats_len > 0) {
+            memcpy(coll_res->ats->data, ats_data, ats_len);
+            coll_res->ats->length = ats_len;
+            return true;
+        }
+        break;
+    }
     }
 
     return false;
@@ -133,7 +174,7 @@ static void text_input_event_cb(mui_text_input_event_t event, mui_text_input_t *
     app_chameleon_t *app = p_text_input->user_data;
     if (event == MUI_TEXT_INPUT_EVENT_CONFIRMED) {
         const char *text = mui_text_input_get_input_text(p_text_input);
-        if (strlen(text) > 0) {
+        if (strlen(text) > 0 || app->id_edit_type == APP_CHAMELEON_ID_EDIT_TYPE_ATS) {
             if (handle_id_edit_cb(app, text)) {
                 mui_scene_dispatcher_previous_scene(app->p_scene_dispatcher);
             } else {
@@ -147,7 +188,7 @@ static void text_input_event_cb(mui_text_input_event_t event, mui_text_input_t *
 
 void chameleon_scene_menu_card_advanced_id_edit_on_enter(void *user_data) {
     app_chameleon_t *app = user_data;
-    char text[32];
+    char text[48];
 
     format_id_edit_text(app->id_edit_type, text);
 


### PR DESCRIPTION
## Summary

- Add RATS/ATS response to the NFC 14A tag emulation layer, enabling cards with SAK bit 6 set (DESFire, JCOP, Type 4 Tags) to complete ISO 14443-4 activation
- Add ISO-DEP block handling (I-blocks, R-blocks, S-blocks, PPS) after RATS/ATS exchange
- Add ATS editing UI in Advanced card settings

## Problem

The card emulator only supports ISO 14443-3A level emulation. When emulating a card with SAK `0x20` (ISO 14443-4 compliant), readers send RATS (`0xE0`) after anti-collision, but the firmware responds with NAK because `ats.length` defaults to `0`. This prevents emulation of DESFire and other ISO 14443-4 cards.

## Changes

### Protocol (`nfc_14a.c` in chameleon-ultra submodule)
- When RATS arrives and no custom ATS is configured but SAK indicates ISO 14443-4 compliance, auto-respond with a default DESFire EV2 ATS (`06 75 77 81 00 80`)
- After RATS/ATS activation, handle ISO-DEP framing: I-blocks (with CID support), R-blocks, S(DESELECT), S(WTX), and PPS
- Reset ISO-DEP state on field loss, HALT, and new anti-collision cycles

### UI (`chameleon_scene_menu_card_advanced*.c`)
- Add ATS field to Advanced card settings showing `[auto]` / `[-]` / `[N B]`
- Add hex editor for custom ATS (dot-separated, e.g. `06.75.77.81.02.80`)
- Empty input clears ATS and reverts to auto mode

## Test plan

- [ ] Configure MiFare Classic slot with custom SAK `0x20`, ATQA `0x0344`, 7-byte UID
- [ ] Verify ATS shows `[auto]` in Advanced settings
- [ ] Present to NFC reader app (e.g. NFC Tools on Android) — should detect as ISO 14443-4 / DESFire
- [ ] Verify existing MiFare Classic and NTAG emulation still works
- [ ] Test custom ATS editing and clearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)