### PR TITLE
fix(web): use caught error variable in action handlers

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -433,7 +433,7 @@ export default {
         }).catch(e => {
           this.$message({
             type: 'error',
-            message: row.name + `${this.$t("format.formaterr")}` + err
+            message: row.name + `${this.$t("format.formaterr")}` + e
           });
           thiz.table_loading = false;
         });
@@ -467,7 +467,7 @@ export default {
         }).catch(e => {
           this.$message({
             type: 'error',
-            message: row.name + `${this.$t("del.error")}` + "[" + err + "]"
+            message: row.name + `${this.$t("del.error")}` + "[" + e + "]"
           });
           thiz.table_loading = false;
         });


### PR DESCRIPTION
Observed
Two error handlers referenced an undefined variable (err) inside catch blocks. When these paths failed, a ReferenceError could mask the original failure.

Root cause
The handlers use catch(e) but interpolated err in the user-facing message.

Fix
Replaced err with e in the two affected catch blocks only.

Manual validation
- Reviewed minimal diff: 1 file changed, 2 replacements only.
- Confirmed the two handlers now reference the caught variable.
- Compatibility impact: no API/protocol/flow changes; behavior unchanged except correct error reporting.