### PR TITLE
chore(warnings): fix const/volatile qualifiers in HAL BLE and DF

### DIFF
--- a/fw/application/src/hal/hal_spi_flash.c
+++ b/fw/application/src/hal/hal_spi_flash.c
@@ -73,7 +73,7 @@ static inline void hal_spi_flash_write_read(uint8_t *tx_data, uint8_t tx_len, ui
     hal_spi_bus_release(&m_dev);
 }
 
-static inline void hal_spi_flash_write_write(uint8_t *tx_data, uint8_t tx_len, uint8_t *tx_data2, uint32_t tx_len2) {
+static inline void hal_spi_flash_write_write(uint8_t *tx_data, uint8_t tx_len, const uint8_t *tx_data2, uint32_t tx_len2) {
     hal_spi_bus_aquire(&m_dev);
 
     spi_transaction_t trans_tx = {
@@ -88,7 +88,7 @@ static inline void hal_spi_flash_write_write(uint8_t *tx_data, uint8_t tx_len, u
 
     if (tx_len2 > 0) {
         spi_transaction_t trans_rx = {
-            .p_tx_buffer = tx_data2,
+            .p_tx_buffer = (void *)tx_data2,
             .tx_length = tx_len2,
             .p_rx_buffer = NULL,
             .rx_length = 0,

--- a/fw/application/src/mod/ble/ble_main.c
+++ b/fw/application/src/mod/ble/ble_main.c
@@ -214,7 +214,7 @@ static void gap_params_init(void) {
  */
 static void nrf_qwr_error_handler(uint32_t nrf_error) { APP_ERROR_HANDLER(nrf_error); }
 
-static void nus_event_async_call_rx_data(void *p_event_data, uint16_t event_size) {
+static void nus_event_async_call_rx_data(const void *p_event_data, uint16_t event_size) {
     // NRF_LOG_INFO("nus_event_async_call_rx_data: bytes=%d", event_size);
     if (m_nus_rx_data_handler) {
         m_nus_rx_data_handler(p_event_data, event_size);

--- a/fw/application/src/mod/df/df_buffer.h
+++ b/fw/application/src/mod/df/df_buffer.h
@@ -18,7 +18,8 @@ typedef struct {
 
 #define NEW_BUFFER(name, _buff, _cap) buffer_t name = {.buff = (_buff), .pos = 0, .limit = 0, .cap = (_cap)}
 
-#define NEW_BUFFER_READ(name, _buff, _limit) buffer_t name = {.buff = (_buff), .pos = 0, .limit = (_limit), .cap = (_limit)}
+#define NEW_BUFFER_READ(name, _buff, _limit)                                                                               \
+    buffer_t name = {.buff = (uint8_t *)(uintptr_t)(_buff), .pos = 0, .limit = (_limit), .cap = (_limit)}
 
 #define NEW_BUFFER_LOCAL(name, _cap)                                                                                   \
     uint8_t _##name##_data[(_cap)];                                                                                    \
@@ -107,7 +108,7 @@ static inline void buff_put_char(buffer_t *buffer, char value) {
  *
  *  @return      : None
  */
-static inline void buff_put_byte_array(buffer_t *buffer, void *value, size_t len) {
+static inline void buff_put_byte_array(buffer_t *buffer, const void *value, size_t len) {
     memcpy(&buffer->buff[buffer->limit], value, len);
     buffer->limit += len;
 }
@@ -120,13 +121,13 @@ static inline void buff_put_byte_array(buffer_t *buffer, void *value, size_t len
  *
  *  @return      : None
  */
-static inline void buff_put_string(buffer_t *buffer, char *string) {
+static inline void buff_put_string(buffer_t *buffer, const char *string) {
     uint16_t len = strlen(string);
     buff_put_u16(buffer, len);
     buff_put_byte_array(buffer, string, len);
 }
 
-static inline void buff_put_string_u8(buffer_t *buffer, char *string) {
+static inline void buff_put_string_u8(buffer_t *buffer, const char *string) {
     uint8_t len = strlen(string);
     buff_put_u8(buffer, len);
     buff_put_byte_array(buffer, string, len);

--- a/fw/application/src/utils.c
+++ b/fw/application/src/utils.c
@@ -22,8 +22,10 @@ ret_code_t utils_rand_bytes(uint8_t rand[], uint8_t bytes) {
 }
 
 void utils_get_device_id(uint8_t *p_device_id) {
-    memcpy(p_device_id, &(NRF_FICR->DEVICEID[0]), 4);
-    memcpy(p_device_id + 4, &(NRF_FICR->DEVICEID[1]), 4);
+    uint32_t device_id0 = NRF_FICR->DEVICEID[0];
+    uint32_t device_id1 = NRF_FICR->DEVICEID[1];
+    memcpy(p_device_id, &device_id0, sizeof(device_id0));
+    memcpy(p_device_id + sizeof(device_id0), &device_id1, sizeof(device_id1));
 }
 
 void int32_to_bytes_le(uint32_t val, uint8_t *data) {


### PR DESCRIPTION
## Summary
- fix volatile/const qualifier warnings in first-party HAL/BLE/DF paths
- keep behavior unchanged (typing-only cleanup)

## Changes
- `utils_get_device_id`: read FICR IDs into locals before memcpy (no volatile-discard)
- `hal_spi_flash_write_write`: accept `const uint8_t *` payload
- BLE RX callback helper now takes `const void *`
- DF buffer helpers accept const input (`NEW_BUFFER_READ`, `buff_put_*`)

## Validation
- `make -C fw/application clean && make -C fw/application pixljs`
- `make -C fw/bootloader`
- confirmed targeted warnings for `utils.c`, `hal_spi_flash.c`, `ble_main.c`, `df_buffer.h` are gone

Related: #428