### PR TITLE
chore(warnings): fix const correctness in MUI and core

### DIFF
--- a/fw/application/src/core/mini_app_launcher.c
+++ b/fw/application/src/core/mini_app_launcher.c
@@ -37,7 +37,7 @@ static void mini_app_launcher_inst_run(mini_app_launcher_t *p_launcher, uint32_t
 }
 
 void mini_app_launcher_run_with_retain_data(mini_app_launcher_t *p_launcher, uint32_t id, uint8_t *retain_data) {
-    mini_app_t *p_app = mini_app_registry_find_by_id(id);
+    const mini_app_t *p_app = mini_app_registry_find_by_id(id);
     if (p_app == NULL) {
         return;
     }
@@ -99,7 +99,7 @@ void mini_app_launcher_sleep(mini_app_launcher_t *p_launcher) {
     cache_data_t *p_cache = cache_get_data();
     if (app) {
         settings_data_t *p_settings = settings_get_data();
-        NRF_LOG_INFO("running APP: %d %s %d", app->p_app->id, nrf_log_push(app->p_app->name),
+        NRF_LOG_INFO("running APP: %d %s %d", app->p_app->id, nrf_log_push((char *)app->p_app->name),
                      app->p_app->hibernate_enabled);
         if (app->p_app->hibernate_enabled == 1 && p_settings->hibernate_enabled == 1) {
             p_cache->id = app->p_app->id;

--- a/fw/application/src/mui/mui_canvas.c
+++ b/fw/application/src/mui/mui_canvas.c
@@ -31,7 +31,7 @@ int32_t mui_canvas_draw_utf8_clip(mui_canvas_t *p_canvas, int32_t x, int32_t y, 
     int32_t yi = y;
     int32_t w = 0;
 
-    char *p = text;
+    const char *p = text;
     char utf8[5];
 
     while (*p != 0) {
@@ -60,7 +60,7 @@ uint8_t mui_canvas_draw_glyph(mui_canvas_t *p_canvas, uint8_t x, uint8_t y, uint
 }
 
 uint16_t mui_canvas_draw_utf8_truncate(mui_canvas_t* p_canvas, uint8_t x, uint8_t y, uint8_t max_width, const char *str) {
-    char *p = str;
+    const char *p = str;
     char utf8[5];
 
     if (max_width < mui_canvas_get_utf8_width(p_canvas, str)) {
@@ -72,7 +72,7 @@ uint16_t mui_canvas_draw_utf8_truncate(mui_canvas_t* p_canvas, uint8_t x, uint8_
                 uint8_t utf8_w = mui_canvas_draw_utf8(p_canvas, x, y, utf8);
                 x += utf8_w;
             } else {
-                uint8_t *font = u8g2_GetFont(p_canvas->fb);
+                const uint8_t *font = u8g2_GetFont(p_canvas->fb);
                 u8g2_SetFont(p_canvas->fb, u8g2_font_siji_t_6x10);
                 uint8_t utf8_w = mui_canvas_draw_glyph(p_canvas, x, y - 1, 0xe21f);
                 u8g2_SetFont(p_canvas->fb, font);

--- a/fw/application/src/mui/mui_element.c
+++ b/fw/application/src/mui/mui_element.c
@@ -45,7 +45,7 @@ void mui_element_autowrap_text(mui_canvas_t *p_canvas, uint8_t x, uint8_t y, uin
     uint8_t xi = x;
     uint8_t yi = y;
 
-    char *p = text;
+    const char *p = text;
     char utf8[5];
 
     while (*p != 0 && yi < y + h) {
@@ -161,7 +161,7 @@ uint16_t mui_element_text_height(mui_canvas_t *p_canvas, uint8_t w, const char *
     uint8_t xi = 0;
     uint16_t yi = 0;
 
-    char *p = text;
+    const char *p = text;
     char utf8[5];
 
     while (*p != 0) {

--- a/fw/application/src/mui/view/mui_text_input.c
+++ b/fw/application/src/mui/view/mui_text_input.c
@@ -297,7 +297,7 @@ void mui_text_input_reset(mui_text_input_t *p_view) {
 
 void mui_text_input_set_focus_key(mui_text_input_t *p_view, char key) {
     for (uint32_t row = 0; row < 3; row++) {
-        mui_text_input_key_t *input_key = get_row(row);
+        const mui_text_input_key_t *input_key = get_row(row);
         for (uint32_t col = 0; col < get_row_size(row); col++) {
             if (input_key[col].text == key) {
                 p_view->focus_column = col;


### PR DESCRIPTION
## Summary
- remove const-discard warnings in MUI text/render helpers and core launcher
- no functional behavior changes

## Changes
- use `const char *` iteration pointers in MUI text utilities
- keep font pointer as const in truncation path
- use const row keys in text input focus search
- use const app pointer in launcher and cast for logging adapter

## Validation
- `make -C fw/application clean && make -C fw/application pixljs`
- `make -C fw/bootloader`
- confirmed warnings for `mui_canvas.c`, `mui_element.c`, `mui_text_input.c`, `mini_app_launcher.c` are gone

Related: #428
Related: #430