### PR TITLE
chore(warnings): normalize pointer types in desktop game and settings

### DIFF
--- a/fw/application/src/app/desktop/app_desktop.c
+++ b/fw/application/src/app/desktop/app_desktop.c
@@ -21,7 +21,7 @@ typedef struct {
 } app_desktop_t;
 
 static void app_desktop_list_view_on_selected(app_list_view_event_t event, app_list_view_t *p_view) {
-    mini_app_t * app = app_list_view_get(p_view, app_list_view_get_focus(p_view));
+    const mini_app_t *app = app_list_view_get(p_view, app_list_view_get_focus(p_view));
     mini_app_launcher_run(mini_app_launcher(), app->id);
 }
 

--- a/fw/application/src/app/desktop/view/app_list_view.h
+++ b/fw/application/src/app/desktop/view/app_list_view.h
@@ -37,12 +37,12 @@ static inline void app_list_view_set_event_cb(app_list_view_t* p_view, app_list_
     p_view->event_cb = event_cb;
 }
 
-static inline void app_list_view_add_app(app_list_view_t* p_view, mini_app_t* p_app){
-    ptr_array_push_back(p_view->items, p_app);
+static inline void app_list_view_add_app(app_list_view_t* p_view, const mini_app_t* p_app){
+    ptr_array_push_back(p_view->items, (void *)p_app);
 }
 
-static inline mini_app_t* app_list_view_get(app_list_view_t* p_view, uint8_t index){
-    return (mini_app_t*) *ptr_array_get(p_view->items, index);
+static inline const mini_app_t* app_list_view_get(app_list_view_t* p_view, uint8_t index){
+    return (const mini_app_t*) *ptr_array_get(p_view->items, index);
 }
 static inline uint8_t app_list_view_get_focus(app_list_view_t* p_view){
     return p_view->focus;

--- a/fw/application/src/app/settings/scene/settings_scene_language.c
+++ b/fw/application/src/app/settings/scene/settings_scene_language.c
@@ -6,13 +6,14 @@
 #include "settings_scene.h"
 #include "utils2.h"
 #include "version2.h"
+#include <stdint.h>
 
 
 static void settings_scene_language_list_view_on_selected(mui_list_view_event_t event, mui_list_view_t *p_list_view,
                                                           mui_list_item_t *p_item) {
 
     app_settings_t *app = p_list_view->user_data;
-    uint32_t selection = (uint32_t)p_item->user_data;
+    uint32_t selection = (uint32_t)(uintptr_t)p_item->user_data;
     settings_data_t *p_settings = settings_get_data();
     if (selection < LANGUAGE_COUNT){
         p_settings->language = selection;
@@ -26,7 +27,7 @@ void settings_scene_language_on_enter(void *user_data) {
 
     app_settings_t *app = user_data;
     for (uint8_t i = 0; i < LANGUAGE_COUNT; i++){
-      mui_list_view_add_item(app->p_list_view, 0xe105, getLangDesc(i), (void *)i);
+      mui_list_view_add_item(app->p_list_view, 0xe105, getLangDesc(i), (void *)(uintptr_t)i);
     }
     mui_list_view_add_item(app->p_list_view, 0xe069, getLangString(_L_BACK), (void *)NULL_USER_DATA);
 

--- a/fw/application/src/hal/hal_spi_bus.c
+++ b/fw/application/src/hal/hal_spi_bus.c
@@ -37,9 +37,9 @@ void hal_spi_bus_attach(spi_device_t *p_dev) {
     nrf_gpio_pin_set(p_dev->cs_pin);
 }
 
-void hal_spi_bus_aquire(spi_device_t *p_dev) { nrf_gpio_pin_clear(p_dev->cs_pin); }
+void hal_spi_bus_aquire(const spi_device_t *p_dev) { nrf_gpio_pin_clear(p_dev->cs_pin); }
 
-void hal_spi_bus_release(spi_device_t *p_dev) { nrf_gpio_pin_set(p_dev->cs_pin); }
+void hal_spi_bus_release(const spi_device_t *p_dev) { nrf_gpio_pin_set(p_dev->cs_pin); }
 
 uint32_t hal_spi_bus_xfer(spi_transaction_t *p_trans) {
     uint32_t err_code = NRF_SUCCESS;

--- a/fw/application/src/hal/hal_spi_bus.h
+++ b/fw/application/src/hal/hal_spi_bus.h
@@ -17,8 +17,8 @@ typedef struct {
 
 void hal_spi_bus_init();
 void hal_spi_bus_attach(spi_device_t *p_dev);
-void hal_spi_bus_aquire(spi_device_t *p_dev);
-void hal_spi_bus_release(spi_device_t *p_dev);
+void hal_spi_bus_aquire(const spi_device_t *p_dev);
+void hal_spi_bus_release(const spi_device_t *p_dev);
 uint32_t hal_spi_bus_xfer(spi_transaction_t *p_trans);
 
 #endif


### PR DESCRIPTION
## Summary
- normalize pointer typing and `uintptr_t` conversions in desktop/game/settings paths
- no behavior changes intended

## Changes
- make SPI CS acquire/release APIs accept `const spi_device_t *`
- use const app pointers in desktop app list accessors/callers
- use `uintptr_t` for list-item user-data conversions in language scene

## Validation
- `make -C fw/application clean && make -C fw/application pixljs`
- `make -C fw/bootloader`
- confirmed warnings from `driver.c`, `app_desktop.c`, and `settings_scene_language.c` are gone

Related: #428
Related: #431