### PR TITLE
chore(warnings): const-correct amiidb db display-name paths

### DIFF
--- a/fw/application/src/amiidb/db_header.h
+++ b/fw/application/src/amiidb/db_header.h
@@ -49,6 +49,6 @@ const db_amiibo_t * get_amiibo_by_id(uint32_t head, uint32_t tail);
 const db_link_t* get_link_by_id(uint8_t game_id, uint32_t head, uint32_t tail);
 bool is_valid_amiibo_v3(uint32_t head, uint32_t tail);
 
-const char* get_amiibo_display_name(db_amiibo_t *amiibo);
+const char* get_amiibo_display_name(const db_amiibo_t *amiibo);
 
 #endif

--- a/fw/application/src/amiidb/db_search.c
+++ b/fw/application/src/amiidb/db_search.c
@@ -36,7 +36,7 @@ bool is_valid_amiibo_v3(uint32_t head, uint32_t tail){
     return (tail & 0xFF) == 0x03;
 }
 
-const char* get_amiibo_display_name(db_amiibo_t *amiibo){
+const char* get_amiibo_display_name(const db_amiibo_t *amiibo){
      uint8_t language = settings_get_data()->language;
     return language == LANGUAGE_ZH_HANS  && amiibo->name_cn[0] != '\0' ? amiibo->name_cn : amiibo->name_en;
 }

--- a/fw/application/src/app/amiidb/scene/amiidb_scene_amiibo_detail_menu.c
+++ b/fw/application/src/app/amiidb/scene/amiidb_scene_amiibo_detail_menu.c
@@ -19,7 +19,7 @@
 
 #include "amiidb_api_slot.h"
 
-static enum amiidb_detail_menu_t {
+enum amiidb_detail_menu_t {
     AMIIDB_DETAIL_MENU_RAND_UID,
     AMIIDB_DETAIL_MENU_AUTO_RAND_UID,
     AMIIDB_DETAIL_MENU_READ_ONLY,


### PR DESCRIPTION
## Summary
- make `get_amiibo_display_name` const-correct (`const db_amiibo_t *`) in header and implementation
- remove useless `static` on enum declaration in `amiidb_scene_amiibo_detail_menu.c`
- keep behavior unchanged while clearing this module warning group

## Validation
- `make -C fw/application clean && make -C fw/application pixljs`
- `make -C fw/bootloader`
- confirmed targeted `amiidb` warnings are gone in app build log

Related: #428
Related: #432