### PR TITLE
chore(warnings): sanitize Chameleon user_data casts and signatures

### DIFF
--- a/fw/application/src/app/chameleon/scene/chameleon_scene_menu_card_advanced.c
+++ b/fw/application/src/app/chameleon/scene/chameleon_scene_menu_card_advanced.c
@@ -14,6 +14,8 @@
 #include "mui_icons.h"
 #include "tag_helper.h"
 
+static void chameleon_scene_menu_card_advanced_reload(app_chameleon_t *app);
+
 typedef enum {
     CHAMELEON_MENU_CUSTOM,
     CHAMELEON_MENU_LOAD_BLOCK0,
@@ -107,7 +109,7 @@ void chameleon_scene_menu_card_advanced_on_event(mui_list_view_event_t event, mu
     }
 }
 
-void chameleon_scene_menu_card_advanced_reload(app_chameleon_t *app) {
+static void chameleon_scene_menu_card_advanced_reload(app_chameleon_t *app) {
     char buff[64];
 
     uint16_t focus = mui_list_view_get_focus(app->p_list_view);

--- a/fw/application/src/app/chameleon/scene/chameleon_scene_menu_card_slot_num_select.c
+++ b/fw/application/src/app/chameleon/scene/chameleon_scene_menu_card_slot_num_select.c
@@ -13,13 +13,14 @@
 
 #include "mui_icons.h"
 #include "tag_helper.h"
+#include <stdint.h>
 
 void chameleon_scene_menu_card_slot_num_select_on_event(mui_list_view_event_t event, mui_list_view_t *p_list_view,
                                                     mui_list_item_t *p_item) {
     app_chameleon_t *app = p_list_view->user_data;
     switch (p_item->icon) {
     case ICON_DATA: {
-        tag_helper_set_slot_num((uint8_t)p_item->user_data);
+        tag_helper_set_slot_num((uint8_t)(uintptr_t)p_item->user_data);
         mui_scene_dispatcher_previous_scene(app->p_scene_dispatcher);
     } break;
 
@@ -33,9 +34,9 @@ void chameleon_scene_menu_card_slot_num_select_on_enter(void *user_data) {
     app_chameleon_t *app = user_data;
 
     // 只添加 8、20、50 三个选项
-    mui_list_view_add_item_ext(app->p_list_view, ICON_DATA, "8", NULL, (void *)8);
-    mui_list_view_add_item_ext(app->p_list_view, ICON_DATA, "20", NULL, (void *)20);
-    mui_list_view_add_item_ext(app->p_list_view, ICON_DATA, "50", NULL, (void *)50);
+    mui_list_view_add_item_ext(app->p_list_view, ICON_DATA, "8", NULL, (void *)(uintptr_t)8);
+    mui_list_view_add_item_ext(app->p_list_view, ICON_DATA, "20", NULL, (void *)(uintptr_t)20);
+    mui_list_view_add_item_ext(app->p_list_view, ICON_DATA, "50", NULL, (void *)(uintptr_t)50);
 
     mui_list_view_add_item(app->p_list_view, ICON_BACK, _T(MAIN_RETURN), NULL_USER_DATA);
 

--- a/fw/application/src/app/chameleon/scene/chameleon_scene_menu_card_slot_select.c
+++ b/fw/application/src/app/chameleon/scene/chameleon_scene_menu_card_slot_select.c
@@ -13,13 +13,14 @@
 
 #include "mui_icons.h"
 #include "tag_helper.h"
+#include <stdint.h>
 
 void chameleon_scene_menu_card_slot_select_on_event(mui_list_view_event_t event, mui_list_view_t *p_list_view,
                                                     mui_list_item_t *p_item) {
     app_chameleon_t *app = p_list_view->user_data;
     switch (p_item->icon) {
     case ICON_DATA: {
-        uint8_t slot = (uint8_t)p_item->user_data;
+        uint8_t slot = (uint8_t)(uintptr_t)p_item->user_data;
         tag_emulation_change_slot(slot, false);
         mui_scene_dispatcher_previous_scene(app->p_scene_dispatcher);
     } break;
@@ -38,7 +39,7 @@ void chameleon_scene_menu_card_slot_select_on_enter(void *user_data) {
     for (uint32_t i = 0; i < TAG_MAX_SLOT_NUM; i++) {
         if (tag_emulation_slot_is_enabled(i, TAG_SENSE_HF)) {
             sprintf(buff, "%s %02d", _T(APP_CHAMELEON_CARD_SLOT), i + 1);
-            mui_list_view_add_item_ext(app->p_list_view, ICON_DATA, buff, NULL, i);
+            mui_list_view_add_item_ext(app->p_list_view, ICON_DATA, buff, NULL, (void *)(uintptr_t)i);
         }
     }
     mui_list_view_add_item(app->p_list_view, ICON_BACK, _T(MAIN_RETURN), NULL_USER_DATA);

--- a/fw/application/src/app/chameleon/scene/chameleon_scene_menu_card_write_mode_select.c
+++ b/fw/application/src/app/chameleon/scene/chameleon_scene_menu_card_write_mode_select.c
@@ -13,13 +13,14 @@
 
 #include "mui_icons.h"
 #include "tag_helper.h"
+#include <stdint.h>
 
 void chameleon_scene_menu_card_write_mode_select_on_event(mui_list_view_event_t event, mui_list_view_t *p_list_view,
                                                           mui_list_item_t *p_item) {
     app_chameleon_t *app = p_list_view->user_data;
     switch (p_item->icon) {
     case ICON_DATA: {
-        uint8_t slot = (uint8_t)p_item->user_data;
+        uint8_t slot = (uint8_t)(uintptr_t)p_item->user_data;
         tag_emulation_change_slot(slot, false);
         nfc_tag_mf1_write_mode_t mode = mui_list_view_get_focus(p_list_view);
         nfc_tag_mf1_set_write_mode(mode);
@@ -35,7 +36,7 @@ void chameleon_scene_menu_card_write_mode_select_on_event(mui_list_view_event_t 
 void chameleon_scene_menu_card_write_mode_select_on_enter(void *user_data) {
     app_chameleon_t *app = user_data;
     for (uint32_t i = 0; i < 4; i++) {
-        mui_list_view_add_item(app->p_list_view, ICON_DATA, tag_helper_get_mf_write_mode_name(i), i);
+        mui_list_view_add_item(app->p_list_view, ICON_DATA, tag_helper_get_mf_write_mode_name(i), (void *)(uintptr_t)i);
     }
     mui_list_view_add_item(app->p_list_view, ICON_BACK, _T(MAIN_RETURN), NULL_USER_DATA);
 


### PR DESCRIPTION
## Summary
- add explicit forward declaration + internal linkage for `chameleon_scene_menu_card_advanced_reload`
- convert pointer/int `user_data` casts in Chameleon slot/write-mode scenes to `uintptr_t`-safe conversions
- keep existing menu/selection behavior unchanged while removing 64-bit cast warnings

## Validation
- `make -C fw/application clean && make -C fw/application pixljs`
- `make -C fw/bootloader`
- warning-gate confirms removed warnings in:
  - `chameleon_scene_menu_card_advanced.c`
  - `chameleon_scene_menu_card_slot_select.c`
  - `chameleon_scene_menu_card_slot_num_select.c`
  - `chameleon_scene_menu_card_write_mode_select.c`

Related: #428
Related: #434