### PR TITLE
fix(settings): auto-recover invalid settings.bin to persist language

### DIFF
--- a/fw/application/src/mod/settings.c
+++ b/fw/application/src/mod/settings.c
@@ -121,22 +121,30 @@ int32_t settings_save() {
     }
 
     settings_data_t old_settings_data;
+    bool needs_write = false;
+    bool needs_meta_update = false;
 
     err = p_driver->read_file_data(SETTINGS_FILE_NAME, &old_settings_data, sizeof(settings_data_t));
-    bool not_found = false;
     if (err == VFS_ERR_NOOBJ) {
-        not_found = true;
+        needs_write = true;
+        needs_meta_update = true;
     } else if (err < 0) {
-        return NRF_ERROR_INVALID_STATE;
+        NRF_LOG_WARNING("settings read failed (%d), recreating settings file", err);
+        needs_write = true;
+    } else if ((size_t)err != sizeof(settings_data_t)) {
+        NRF_LOG_WARNING("settings size mismatch (%d != %d), recreating settings file", err, (int)sizeof(settings_data_t));
+        needs_write = true;
+    } else if (memcmp(&m_settings_data, &old_settings_data, sizeof(settings_data_t)) != 0) {
+        needs_write = true;
     }
 
-    if (not_found || memcmp(&m_settings_data, &old_settings_data, sizeof(settings_data_t)) != 0) {
+    if (needs_write) {
         err = p_driver->write_file_data(SETTINGS_FILE_NAME, &m_settings_data, sizeof(settings_data_t));
         if (err < 0) {
             return NRF_ERROR_INVALID_STATE;
         }
 
-        if (not_found) {
+        if (needs_meta_update) {
             vfs_meta_t meta;
             memset(&meta, 0, sizeof(meta));
             meta.has_flags = true;


### PR DESCRIPTION
## Summary
- make `settings_save()` recover when `/settings.bin` is invalid/incompatible instead of returning early
- recreate the settings file on read failure or struct-size mismatch
- keep hidden metadata creation only for first-time file creation (`VFS_ERR_NOOBJ`)

## Why
Issue #369 reports language resetting to English after sleep/restart. In this flow, settings load/save could fail against a stale/corrupted settings file and never rewrite it, so defaults kept applying.

## Behavior
- valid settings file: unchanged behavior (write only when changed)
- missing settings file: unchanged behavior (create + hidden metadata)
- invalid/corrupted/mismatched settings file: now rewrites with current in-memory settings instead of failing

## Validation
- `make -C fw/application clean && make -C fw/application pixljs` ✅
- `make -C fw/bootloader` ✅
- `cd web && npm run build` ✅

## Notes
- Hardware runtime validation is still pending (no device connected in this environment).

Fixes #369
