### PR TITLE
ci(fw): add firmware size reporting

### DIFF
--- a/.github/workflows/pixl.js-fw.yml
+++ b/.github/workflows/pixl.js-fw.yml
@@ -5,9 +5,12 @@ on:
     branches: [ "develop", "neo_v2"]
     tags:  ["*"]
   pull_request:
-    types: ["opened"]
+    types: ["opened", "synchronize", "reopened"]
     branches: ["develop"]
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -25,12 +28,57 @@ jobs:
       run: chown root:root .
     - name: build firmware
       run: cd fw && make all RELEASE=1 APP_VERSION=$GITHUB_RUN_NUMBER BOARD=${{matrix.board}}
+    - name: generate size report
+      run: cd fw && make size_report RELEASE=1 APP_VERSION=$GITHUB_RUN_NUMBER BOARD=${{matrix.board}}
+    - name: compare size against PR base (bytes)
+      run: |
+        set -eu
+        HEAD_REPORT_JSON="fw/_build/size_report_${{matrix.board}}.json"
+        COMPARISON_MD="fw/_build/size_comparison_${{matrix.board}}.md"
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          BASE_WORKTREE="/tmp/pixljs-base-${{matrix.board}}-${{ github.run_id }}-${{ github.run_attempt }}"
+          git fetch --no-tags --depth=1 origin "${BASE_SHA}"
+          trap 'git worktree remove "${BASE_WORKTREE}" --force || true' EXIT
+          git worktree add "${BASE_WORKTREE}" "${BASE_SHA}"
+          git -C "${BASE_WORKTREE}" submodule update --init --recursive
+          make -C "${BASE_WORKTREE}/fw" all RELEASE=1 APP_VERSION=$GITHUB_RUN_NUMBER BOARD=${{matrix.board}}
+          python3 fw/scripts/size_report.py summarize \
+            --bin "${BASE_WORKTREE}/fw/_build/pixljs.bin" \
+            --elf "${BASE_WORKTREE}/fw/_build/pixljs.out" \
+            --map "${BASE_WORKTREE}/fw/_build/pixljs.map" \
+            --top-symbols 20 \
+            --top-objects 20 \
+            --board "${{matrix.board}}" \
+            --release 1 \
+            --out-prefix "${BASE_WORKTREE}/fw/_build/size_report_${{matrix.board}}"
+          python3 fw/scripts/size_report.py compare \
+            --base "${BASE_WORKTREE}/fw/_build/size_report_${{matrix.board}}.json" \
+            --head "${HEAD_REPORT_JSON}" \
+            --output "${COMPARISON_MD}"
+          cp "${BASE_WORKTREE}/fw/_build/size_report_${{matrix.board}}.json" "fw/_build/size_report_base_${{matrix.board}}.json"
+          cp "${BASE_WORKTREE}/fw/_build/size_report_${{matrix.board}}.txt" "fw/_build/size_report_base_${{matrix.board}}.txt"
+        else
+          echo "Baseline comparison is available on pull_request runs only." > "${COMPARISON_MD}"
+        fi
     - name: copy artifact
-      run: mv fw/_build/bootloader.hex . && mv fw/_build/pixljs.hex . && mv fw/_build/pixljs_all.hex . && mv fw/_build/pixjs_ota_v${{github.run_number}}.zip . && mv fw/docs/fw_readme.txt . && mv  fw/scripts/fw_update.bat .
+      run: |
+        mv fw/_build/bootloader.hex .
+        mv fw/_build/pixljs.hex .
+        mv fw/_build/pixljs_all.hex .
+        mv fw/_build/pixjs_ota_v${{github.run_number}}.zip .
+        mv fw/docs/fw_readme.txt .
+        mv fw/scripts/fw_update.bat .
+        cp fw/_build/size_report_${{matrix.board}}.txt .
+        cp fw/_build/size_report_${{matrix.board}}.json .
+        cp fw/_build/size_comparison_${{matrix.board}}.md .
+        if [ -f fw/_build/size_report_base_${{matrix.board}}.txt ]; then cp fw/_build/size_report_base_${{matrix.board}}.txt .; fi
+        if [ -f fw/_build/size_report_base_${{matrix.board}}.json ]; then cp fw/_build/size_report_base_${{matrix.board}}.json .; fi
     - name: upload artifact
       uses: actions/upload-artifact@v7
       with:
         name: pixljs_fw_${{matrix.board}}
+        if-no-files-found: error
         path: |
           bootloader.hex
           pixljs.hex
@@ -38,3 +86,88 @@ jobs:
           pixjs_ota_v${{github.run_number}}.zip
           fw_readme.txt
           fw_update.bat
+          size_report_${{matrix.board}}.txt
+          size_report_${{matrix.board}}.json
+          size_comparison_${{matrix.board}}.md
+          size_report_base_${{matrix.board}}.txt
+          size_report_base_${{matrix.board}}.json
+
+  publish-size-report:
+    needs: build
+    if: ${{ always() && github.event_name == 'pull_request' && needs.build.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+    - name: download firmware size reports
+      uses: actions/download-artifact@v7
+      with:
+        pattern: pixljs_fw_*
+        path: size-reports
+        merge-multiple: false
+
+    - name: assemble PR size report
+      run: |
+        {
+          echo '<!-- pixljs-firmware-size-report -->'
+          echo '## Firmware Size Report'
+          echo
+          echo "Generated from [workflow run ${GITHUB_RUN_NUMBER}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})."
+          echo
+          for board in LCD OLED; do
+            report="size-reports/pixljs_fw_${board}/size_comparison_${board}.md"
+            if [ -f "${report}" ]; then
+              sed 's/^# Size Comparison/### Size Comparison/' "${report}"
+            else
+              echo "### Size Comparison (${board})"
+              echo
+              echo "No size comparison report was generated for this board."
+            fi
+            echo
+          done
+        } > size_report_comment.md
+        cat size_report_comment.md >> "${GITHUB_STEP_SUMMARY}"
+
+    - name: update PR size report comment when permitted
+      uses: actions/github-script@v8
+      with:
+        script: |
+          const fs = require("fs");
+          const marker = "<!-- pixljs-firmware-size-report -->";
+          const body = fs.readFileSync("size_report_comment.md", "utf8");
+          const { owner, repo } = context.repo;
+          const issue_number = context.issue.number;
+          try {
+            const { data: comments } = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const previous = comments.find((comment) =>
+              comment.user?.type === "Bot" && comment.body?.includes(marker)
+            );
+            if (previous) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: previous.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+          } catch (error) {
+            core.notice(
+              `Unable to update the PR size report comment: ${error.message}. ` +
+                "The same report is available in the workflow summary and artifacts."
+            );
+          }

--- a/fw/Makefile
+++ b/fw/Makefile
@@ -1,4 +1,4 @@
-.PHONY: app bl clean
+.PHONY: app bl clean size_report size_report_files
 
 all: bl app ota
 
@@ -13,3 +13,9 @@ ota:
 
 clean:
 	@rm -rf _build/
+
+size_report:
+	@$(MAKE) -C application/ size_report
+
+size_report_files:
+	@$(MAKE) -C application/ size_report_files

--- a/fw/application/Makefile
+++ b/fw/application/Makefile
@@ -11,6 +11,8 @@ CHAMELEON_ROOT :=$(COMP_DIR)/chameleon-ultra/firmware
 APP_VERSION ?= 1
 RELEASE ?= 1
 BOARD ?= OLED
+FW_TOP_SYMBOLS ?= 20
+FW_TOP_OBJECTS ?= 20
 
 $(OUTPUT_DIRECTORY)/pixljs.out: \
   LINKER_SCRIPT  := ../ld/application.ld
@@ -717,6 +719,7 @@ include $(TEMPLATE_PATH)/Makefile.common
 $(foreach target, $(TARGETS), $(call define_target, $(target)))
 
 .PHONY: flash flash_softdevice erase
+.PHONY: size_report size_report_files
 
 # Flash the program
 flash: default
@@ -781,3 +784,17 @@ flash_bmp:
 		-ex 'compare-sections' \
 		-ex 'kill' \
 		$(OUTPUT_DIRECTORY)/pixljs.out
+
+size_report_files: $(OUTPUT_DIRECTORY)/pixljs.bin $(OUTPUT_DIRECTORY)/pixljs.out $(OUTPUT_DIRECTORY)/pixljs.map
+	@python3 ../scripts/size_report.py summarize \
+		--bin $(OUTPUT_DIRECTORY)/pixljs.bin \
+		--elf $(OUTPUT_DIRECTORY)/pixljs.out \
+		--map $(OUTPUT_DIRECTORY)/pixljs.map \
+		--top-symbols $(FW_TOP_SYMBOLS) \
+		--top-objects $(FW_TOP_OBJECTS) \
+		--board $(BOARD) \
+		--release $(RELEASE) \
+		--out-prefix $(OUTPUT_DIRECTORY)/size_report_$(BOARD)
+
+size_report: size_report_files
+	@cat $(OUTPUT_DIRECTORY)/size_report_$(BOARD).txt

--- a/fw/scripts/size_report.py
+++ b/fw/scripts/size_report.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+SIZE_LINE_RE = re.compile(
+    r"^\s*(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+([0-9a-fA-F]+)\s+(.+)$"
+)
+MAP_ENTRY_RE = re.compile(
+    r"^\s*\.(text|rodata|data|bss)(?:\.[^\s]*)?\s+0x[0-9a-fA-F]+\s+0x([0-9a-fA-F]+)\s+(\S+\.o(?:\))?)\s*$",
+    re.M,
+)
+
+
+def run_command(command):
+    return subprocess.check_output(command, text=True, stderr=subprocess.STDOUT)
+
+
+def parse_size_output(raw_output):
+    for line in raw_output.splitlines():
+        match = SIZE_LINE_RE.match(line)
+        if not match:
+            continue
+        text, data, bss, dec, hex_size, _filename = match.groups()
+        return {
+            "text": int(text),
+            "data": int(data),
+            "bss": int(bss),
+            "dec": int(dec),
+            "hex": int(hex_size, 16),
+        }
+    raise ValueError("Unable to parse arm-none-eabi-size output.")
+
+
+def collect_top_symbols(elf_path, top_count, max_symbol_size=None):
+    nm_output = run_command(["arm-none-eabi-nm", "-S", "--size-sort", str(elf_path)])
+    symbols = []
+    for line in nm_output.splitlines():
+        parts = line.strip().split()
+        if len(parts) < 4:
+            continue
+        symbol_type = parts[2]
+        if symbol_type not in {"T", "t", "R", "r", "D", "d", "B", "b"}:
+            continue
+        try:
+            size = int(parts[1], 16)
+        except ValueError:
+            continue
+        if size <= 0:
+            continue
+        if max_symbol_size is not None and size > max_symbol_size:
+            continue
+        symbols.append(
+            {
+                "address": parts[0],
+                "size": size,
+                "type": symbol_type,
+                "name": " ".join(parts[3:]),
+            }
+        )
+    return symbols[-top_count:]
+
+
+def collect_object_totals(map_path):
+    map_text = map_path.read_text(encoding="utf-8", errors="ignore")
+    marker = "Linker script and memory map"
+    marker_index = map_text.find(marker)
+    if marker_index >= 0:
+        map_text = map_text[marker_index:]
+
+    object_totals = {}
+    for _section, size_hex, object_path in MAP_ENTRY_RE.findall(map_text):
+        object_totals.setdefault(object_path.strip(), 0)
+        object_totals[object_path.strip()] += int(size_hex, 16)
+    return object_totals
+
+
+def collect_top_objects(object_totals, top_count):
+    objects_sorted = sorted(object_totals.items(), key=lambda item: item[1], reverse=True)
+    return [{"object": obj, "size": size} for obj, size in objects_sorted[:top_count]]
+
+
+def write_summary_report(output_prefix, metrics):
+    text_lines = []
+    text_lines.append(f"=== Firmware size report ({metrics['board']}, RELEASE={metrics['release']}) ===")
+    text_lines.append(f"pixljs.bin bytes: {metrics['bin_bytes']}")
+    text_lines.append(
+        "Sections (.text/.data/.bss/dec/hex): "
+        f"{metrics['sections']['text']} / {metrics['sections']['data']} / "
+        f"{metrics['sections']['bss']} / {metrics['sections']['dec']} / 0x{metrics['sections']['hex']:x}"
+    )
+    text_lines.append("")
+    text_lines.append(f"Top {len(metrics['top_symbols'])} symbols by size:")
+    for symbol in metrics["top_symbols"]:
+        text_lines.append(
+            f"{symbol['size']:8d}  {symbol['type']}  {symbol['name']}"
+        )
+    text_lines.append("")
+    text_lines.append(f"Top {len(metrics['top_objects'])} object contributions (.text/.rodata/.data/.bss):")
+    for item in metrics["top_objects"]:
+        text_lines.append(f"{item['size']:8d}  {item['object']}")
+    text_lines.append("")
+
+    text_path = Path(f"{output_prefix}.txt")
+    json_path = Path(f"{output_prefix}.json")
+    text_path.write_text("\n".join(text_lines), encoding="utf-8")
+    json_path.write_text(json.dumps(metrics, indent=2, sort_keys=True), encoding="utf-8")
+    return text_path, json_path
+
+
+def summarize(args):
+    bin_path = Path(args.bin)
+    elf_path = Path(args.elf)
+    map_path = Path(args.map)
+
+    sections_output = run_command(["arm-none-eabi-size", str(elf_path)])
+    sections = parse_size_output(sections_output)
+    top_symbols = collect_top_symbols(elf_path, args.top_symbols, max_symbol_size=sections["dec"])
+    object_totals = collect_object_totals(map_path)
+    top_objects = collect_top_objects(object_totals, args.top_objects)
+
+    metrics = {
+        "board": args.board,
+        "release": args.release,
+        "bin_bytes": bin_path.stat().st_size,
+        "sections": sections,
+        "top_symbols": top_symbols,
+        "top_objects": top_objects,
+        "object_totals": object_totals,
+    }
+    text_path, json_path = write_summary_report(args.out_prefix, metrics)
+    print(f"Wrote summary report: {text_path}")
+    print(f"Wrote metrics json: {json_path}")
+
+
+def build_object_map(entries):
+    if isinstance(entries, dict):
+        return {str(key): int(value) for key, value in entries.items()}
+    return {item["object"]: int(item["size"]) for item in entries}
+
+
+def top_object_deltas(base_objects, head_objects, top_count):
+    all_keys = set(base_objects) | set(head_objects)
+    deltas = []
+    for key in all_keys:
+        base_size = int(base_objects.get(key, 0))
+        head_size = int(head_objects.get(key, 0))
+        delta = head_size - base_size
+        if delta == 0:
+            continue
+        deltas.append(
+            {
+                "object": key,
+                "base": base_size,
+                "head": head_size,
+                "delta": delta,
+                "abs_delta": abs(delta),
+            }
+        )
+    deltas.sort(key=lambda item: item["abs_delta"], reverse=True)
+    return deltas[:top_count]
+
+
+def compare(args):
+    base_metrics = json.loads(Path(args.base).read_text(encoding="utf-8"))
+    head_metrics = json.loads(Path(args.head).read_text(encoding="utf-8"))
+
+    delta_bin = int(head_metrics["bin_bytes"]) - int(base_metrics["bin_bytes"])
+    delta_text = int(head_metrics["sections"]["text"]) - int(base_metrics["sections"]["text"])
+    delta_data = int(head_metrics["sections"]["data"]) - int(base_metrics["sections"]["data"])
+    delta_bss = int(head_metrics["sections"]["bss"]) - int(base_metrics["sections"]["bss"])
+    delta_dec = int(head_metrics["sections"]["dec"]) - int(base_metrics["sections"]["dec"])
+
+    base_objects = build_object_map(base_metrics.get("object_totals", base_metrics.get("top_objects", [])))
+    head_objects = build_object_map(head_metrics.get("object_totals", head_metrics.get("top_objects", [])))
+    object_deltas = top_object_deltas(base_objects, head_objects, args.top_objects)
+
+    lines = []
+    lines.append(f"# Size Comparison ({head_metrics.get('board', 'unknown')})")
+    lines.append("")
+    lines.append("| Metric | Base | Head | Delta |")
+    lines.append("|---|---:|---:|---:|")
+    lines.append(
+        f"| `pixljs.bin` bytes | {base_metrics['bin_bytes']} | {head_metrics['bin_bytes']} | {delta_bin:+d} |"
+    )
+    lines.append(
+        f"| `.text` | {base_metrics['sections']['text']} | {head_metrics['sections']['text']} | {delta_text:+d} |"
+    )
+    lines.append(
+        f"| `.data` | {base_metrics['sections']['data']} | {head_metrics['sections']['data']} | {delta_data:+d} |"
+    )
+    lines.append(
+        f"| `.bss` | {base_metrics['sections']['bss']} | {head_metrics['sections']['bss']} | {delta_bss:+d} |"
+    )
+    lines.append(
+        f"| `dec` | {base_metrics['sections']['dec']} | {head_metrics['sections']['dec']} | {delta_dec:+d} |"
+    )
+
+    lines.append("")
+    lines.append("## Top Object Deltas (from map summary)")
+    lines.append("")
+    if object_deltas:
+        lines.append("| Object | Base | Head | Delta |")
+        lines.append("|---|---:|---:|---:|")
+        for item in object_deltas:
+            lines.append(
+                f"| `{item['object']}` | {item['base']} | {item['head']} | {item['delta']:+d} |"
+            )
+    else:
+        lines.append("No object-level deltas found in the compared summaries.")
+
+    output_path = Path(args.output)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"Wrote comparison report: {output_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate and compare firmware size reports.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    summarize_parser = subparsers.add_parser("summarize", help="Generate a size report from build artifacts.")
+    summarize_parser.add_argument("--bin", required=True, help="Path to pixljs.bin")
+    summarize_parser.add_argument("--elf", required=True, help="Path to pixljs.out")
+    summarize_parser.add_argument("--map", required=True, help="Path to pixljs.map")
+    summarize_parser.add_argument("--top-symbols", type=int, default=20, help="Top symbols to include")
+    summarize_parser.add_argument("--top-objects", type=int, default=20, help="Top objects to include")
+    summarize_parser.add_argument("--board", default="unknown", help="Board name for report metadata")
+    summarize_parser.add_argument("--release", default="1", help="Release flag metadata")
+    summarize_parser.add_argument("--out-prefix", required=True, help="Output prefix for .txt/.json")
+    summarize_parser.set_defaults(func=summarize)
+
+    compare_parser = subparsers.add_parser("compare", help="Compare two JSON size reports.")
+    compare_parser.add_argument("--base", required=True, help="Baseline size_report_*.json")
+    compare_parser.add_argument("--head", required=True, help="Head size_report_*.json")
+    compare_parser.add_argument("--output", required=True, help="Output markdown file path")
+    compare_parser.add_argument("--top-objects", type=int, default=20, help="Top object deltas to print")
+    compare_parser.set_defaults(func=compare)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add firmware size report generation for LCD and OLED builds
- publish text/JSON size reports as firmware CI artifacts
- publish PR-base Markdown size comparisons for pull request runs
- keep this PR limited to reporting only: no runtime Amiibo/i18n data-layout changes, no LTO, and no size budget gate

## Why
Firmware size is tight, and generated firmware artifacts make size regressions hard to inspect. This PR adds reporting and PR-base comparison artifacts so future firmware-size changes can be reviewed with concrete numbers, without changing firmware runtime behavior.

## Validation
- `git diff --check origin/develop...HEAD` OK
- `python3 -B -m py_compile fw/scripts/size_report.py` OK
- `pixl.js-fw` CI passed for LCD and OLED on run 25052290241

## Notes
- The compact generated data-layout change was dropped after the non-LTO saving measured only about 12.9 KB, which did not seem worth the added generator/runtime complexity.
- LTO remains out of scope because it previously caused reboot/freeze issues and should only be revisited separately with hardware testing.