### PR TITLE
fix(vfs): rename LFS directories to requested path

### DIFF
--- a/fw/application/src/mod/vfs/vfs_driver_lfs.c
+++ b/fw/application/src/mod/vfs/vfs_driver_lfs.c
@@ -273,7 +273,7 @@ int32_t vfs_lfs_remove_dir(const char *dir) {
 }
 
 int32_t vfs_lfs_rename_dir(const char *old_dir, const char *new_dir) {
-    int32_t err = lfs_rename(&lfs, old_dir, old_dir);
+    int32_t err = lfs_rename(&lfs, old_dir, new_dir);
     return vfs_lfs_map_error_code(err);
 }
 


### PR DESCRIPTION
## Summary
- fix the LFS VFS driver's directory rename path
- pass the requested destination path to `lfs_rename()` instead of renaming the directory to itself

## Why
While triaging #225, I noticed a separate LFS-only directory rename bug: `vfs_lfs_rename_dir(old_dir, new_dir)` ignored `new_dir` and called `lfs_rename(&lfs, old_dir, old_dir)`.

The current OLED/LCD board configs use SPIFFS, so this is not the root cause of #225. That issue appears to be a duplicate/already-answered case of #219, where invalid filenames created before filename validation require storage formatting to recover. This PR only fixes the unrelated LFS rename bug found during that check.

## Validation
- `git diff --check` ✅
- `NRF52_SDK_ROOT=/Users/xndvaz/dev/pixl.js/fw/components/chameleon-ultra/firmware/nrf52_sdk make -C fw/application clean` ✅
- `NRF52_SDK_ROOT=/Users/xndvaz/dev/pixl.js/fw/components/chameleon-ultra/firmware/nrf52_sdk GNU_INSTALL_ROOT=/opt/homebrew/bin/ make -C fw/application pixljs` ❌ blocked locally by incomplete toolchain/SDK environment (`mbedtls` sources missing under the local SDK checkout and `stdint.h` not found by the local ARM toolchain)

Related: #225
