### PR TITLE
docs: clarify wrong firmware recovery steps

### DIFF
--- a/docs/en/02-Flash-Firmware.md
+++ b/docs/en/02-Flash-Firmware.md
@@ -63,7 +63,7 @@ You can use either method below to recover.
 
 ## Option 1: Flash the firmware via wired connection
 
-If you have any CMASS-DAP compatible JLink or DAPLink programmer on hand, you can use the [Wired Method](#method-1-wired) to flash the correct firmware version manually.
+If you have any CMASS-DAP-compatible JLink or DAPLink programmer on hand, you can use the [Wired Method](#method-1-wired) to flash the correct firmware version manually.
 
 
 ## Option 2: Enter DFU mode with the key sequence.

--- a/docs/en/02-Flash-Firmware.md
+++ b/docs/en/02-Flash-Firmware.md
@@ -83,4 +83,4 @@ The screen may still show stripes or a garbled image while the device is in DFU 
 
 If blind menu navigation fails, use the bootloader DFU button instead: power off the device, hold RIGHT for about 3 seconds while powering on, and wait until the device advertises as `pixl dfu`.
 
-Now the device is in DFU mode. Use either the [nRF Connect APP](#nrf-connect-app) or the [Firmware Update Page](#directly-to-the-firmware-update-page) to flash the correct `pixjs_ota_vxxx.zip` file for your hardware version. If the web update stalls, start the update again; DFU can resume. If the official web page does not find the device or the browser update keeps stalling, use nRF Connect or the wired method instead.
+Now the device is in DFU mode. Use either the [nRF Connect APP](#nrf-connect-app) or the [Firmware Update Page](#directly-to-the-firmware-update-page) to flash the correct `pixjs_ota_vxxx.zip` file for your hardware version. If the web update stalls, start the update again; DFU can resume. If the official web page does not find the device or the browser update continues to stall, use nRF Connect or the wired method instead.

--- a/docs/en/02-Flash-Firmware.md
+++ b/docs/en/02-Flash-Firmware.md
@@ -81,4 +81,6 @@ If you do not know which version was flashed, try LEFT 5 times first because cur
 
 The screen may still show stripes or a garbled image while the device is in DFU mode. This is expected when the wrong display firmware is installed.
 
+If blind menu navigation fails, use the bootloader DFU button instead: power off the device, hold RIGHT for about 3 seconds while powering on, and wait until the device advertises as `pixl dfu`.
+
 Now the device is in DFU mode. Use either the [nRF Connect APP](#nrf-connect-app) or the [Firmware Update Page](#directly-to-the-firmware-update-page) to flash the correct `pixjs_ota_vxxx.zip` file for your hardware version. If the web update stalls, start the update again; DFU can resume. If the official web page does not find the device or the browser update keeps stalling, use nRF Connect or the wired method instead.

--- a/docs/en/02-Flash-Firmware.md
+++ b/docs/en/02-Flash-Firmware.md
@@ -3,7 +3,7 @@ After you build the hardware you need to flash the firmware for the first time, 
 The firmware can be flashed or upgraded using one of the follow methods:
 
 ## Method 1: Wired
-This method requires a CMASS-DAP compatible JLink or DAPLink flasher.  We recommend PWLINK2 Lite Emulator STM32 Programmer, you can buy one for about 9.9 yuan on [Taobao](https://item.taobao.com/item.htm?spm=a1z09.2.0.0.4b942e8deXyaQO&id=675067753017&_u=d2p75qfn774a "Taobao")
+This method requires a CMSIS-DAP-compatible JLink or DAPLink flasher.  We recommend PWLINK2 Lite Emulator STM32 Programmer, you can buy one for about 9.9 yuan on [Taobao](https://item.taobao.com/item.htm?spm=a1z09.2.0.0.4b942e8deXyaQO&id=675067753017&_u=d2p75qfn774a "Taobao")
 
 Download the latest version of the firmware zip package. It should contain next files:
 - fw_update.bat
@@ -63,7 +63,7 @@ You can use either method below to recover.
 
 ## Option 1: Flash the firmware via wired connection
 
-If you have any CMASS-DAP-compatible JLink or DAPLink programmer on hand, you can use the [Wired Method](#method-1-wired) to flash the correct firmware version manually.
+If you have any CMSIS-DAP-compatible JLink or DAPLink programmer on hand, you can use the [Wired Method](#method-1-wired) to flash the correct firmware version manually.
 
 
 ## Option 2: Enter DFU mode with the key sequence.
@@ -81,6 +81,6 @@ If you do not know which version was flashed, try LEFT 5 times first because cur
 
 The screen may still show stripes or a garbled image while the device is in DFU mode. This is expected when the wrong display firmware is installed.
 
-If blind menu navigation fails, use the bootloader DFU button instead: power off the device, hold RIGHT for about 3 seconds while powering on, and wait until the device advertises as `pixl dfu`.
+If blind menu navigation fails, use the bootloader DFU button instead: power off the device, then hold RIGHT and power on the device while continuing to hold RIGHT for about 3 seconds until the device advertises as `pixl dfu`.
 
 Now the device is in DFU mode. Use either the [nRF Connect APP](#nrf-connect-app) or the [Firmware Update Page](#directly-to-the-firmware-update-page) to flash the correct `pixjs_ota_vxxx.zip` file for your hardware version. If the web update stalls, start the update again; DFU can resume. If the official web page does not find the device or the browser update continues to stall, use nRF Connect or the wired method instead.

--- a/docs/en/02-Flash-Firmware.md
+++ b/docs/en/02-Flash-Firmware.md
@@ -57,27 +57,28 @@ Then press the `SELECT DEVICE` button on the page you should see a device called
 
 # Repair wrong firmware version.
 
-If by mistake you program the wrong version (LCD/OLED) on your device, the device will work but will no show information on screen, the backlight of the LCD version could turn on.
+If you accidentally flash the wrong hardware version (LCD/OLED), the device can still boot, but the display driver will not match the screen. You may only see stripes, a garbled screen, or the LCD backlight. The display will stay this way until you flash the firmware that matches your hardware.
 
-You can use following methods to recover or flash the correct firmware version.
+You can use either method below to recover.
 
 ## Option 1: Flash the firmware via wired connection
 
-If you have any CMASS-DAP compatible JLink or DAPLink programer on hand, you can use the [Wired Method](Flash-Firmware#Method 1: Wired "Wired Method") to flash the correct firmware version manually.
+If you have any CMASS-DAP compatible JLink or DAPLink programmer on hand, you can use the [Wired Method](#method-1-wired) to flash the correct firmware version manually.
 
 
-## Option 2: Follow special key sequences to enter the DFU mode again to flash correct firmware version.
+## Option 2: Enter DFU mode with the key sequence.
 
-First make sure your device is in off state, then press key sequences bellow to enter into the `DFU Mode`
+Because the screen is unreadable, enter `DFU Mode` by pressing the buttons blindly:
 
-- Any key to wake up the device
-- LEFT
-- MIDDLE
-- LEFT X N 
-- MIDDLE
+1. Make sure your device is off.
+2. Press any key once to wake up the device.
+3. Press LEFT once.
+4. Press MIDDLE once.
+5. Press LEFT 4 times if the wrong firmware is older than 2.11.x, or LEFT 5 times if it is 2.11.x or newer.
+6. Press MIDDLE once.
 
-If the firmware version before 2.11.x, press LEFT x 4
-If the firmware version after 2.11.x, press LEFT x 5
+If you do not know which version was flashed, try LEFT 5 times first because current releases use that menu position. If the device does not advertise as `pixl dfu`, power it off and try again with LEFT 4 times.
 
-Now you device is on DFU mode, use any of the [nRF Connect APP](#nRF-Connect-APP)  or [Directly to the Firmware Update Page](#directly-to-the-firmware-update-page) methods to upgrade the fimware.
+The screen may still show stripes or a garbled image while the device is in DFU mode. This is expected when the wrong display firmware is installed.
 
+Now the device is in DFU mode. Use either the [nRF Connect APP](#nrf-connect-app) or the [Firmware Update Page](#directly-to-the-firmware-update-page) to flash the correct `pixjs_ota_vxxx.zip` file for your hardware version. If the web update stalls, start the update again; DFU can resume. If the official web page does not find the device or the browser update keeps stalling, use nRF Connect or the wired method instead.


### PR DESCRIPTION
## Summary

- clarify the recovery flow for accidentally flashing the wrong LCD/OLED firmware
- replace the ambiguous `LEFT X N` instruction with explicit button counts
- document that stripes/garbled display are expected until the correct firmware is flashed
- add DFU fallback guidance when the web update stalls or the device is not found

## Why

Issue #267 shows users can misread the blind DFU sequence and expect the screen to recover before the correct firmware is installed. The support case was resolved, but the docs can make the recovery path clearer.

Related: #267

## Validation

- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote firmware-recovery guidance to explain wrong‑firmware symptoms as hardware‑version (screen) mismatches and expected display behavior.
  * Clarified DFU entry methods (including bootloader button hold) and provided a numbered blind key‑sequence DFU workflow.
  * Added advice for unknown versions, expected garbling during DFU, requirement to use hardware‑specific firmware files, and web/browser and wired fallback procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->