### PR TITLE
docs: add issue triage templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,92 @@
+name: Bug report
+description: Report a reproducible firmware, web, NFC, or hardware issue.
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please include enough detail for maintainers
+        to reproduce it on the same firmware and hardware target.
+  - type: input
+    id: firmware-version
+    attributes:
+      label: Firmware version
+      description: Include the version shown in Settings > Version, if available.
+      placeholder: "Example: 2.13.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: target
+    attributes:
+      label: Hardware target
+      options:
+        - LCD
+        - OLED
+        - Not sure
+    validations:
+      required: true
+  - type: input
+    id: hardware-source
+    attributes:
+      label: Hardware/vendor
+      description: Where did the device or PCB come from?
+      placeholder: "Example: self-built, Taobao kit, AliExpress, Wuzplay, unknown"
+    validations:
+      required: true
+  - type: dropdown
+    id: affected-area
+    attributes:
+      label: Affected area
+      options:
+        - Firmware update / DFU
+        - Amiibo Emulator
+        - Amiibo Database
+        - AmiiboLink
+        - Card Emulator
+        - BLE File Transfer
+        - Settings
+        - Web page
+        - Hardware / display
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: List the exact steps needed to trigger the issue.
+      placeholder: |
+        1. Open ...
+        2. Select ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Screenshots, logs, or photos
+      description: Attach anything that helps identify the issue.
+    validations:
+      required: false
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you tried?
+      description: Mention docs, recovery steps, apps, browsers, or firmware files already tested.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Pixl.js community Discord
     url: https://discord.gg/4mqeQwcAB2

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Pixl.js community Discord
+    url: https://discord.gg/4mqeQwcAB2
+    about: Ask usage questions and discuss hardware builds with the community.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,27 @@
+name: Documentation
+description: Request a documentation fix, clarification, or new guide.
+title: "[Docs] "
+labels: ["documentation"]
+body:
+  - type: textarea
+    id: page
+    attributes:
+      label: Page or topic
+      description: Which page, section, or workflow needs documentation?
+      placeholder: "Example: firmware update recovery, card emulator import/export"
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is unclear or missing?
+      description: Describe the missing, outdated, or confusing part.
+    validations:
+      required: true
+  - type: textarea
+    id: suggested-change
+    attributes:
+      label: Suggested change
+      description: Optional wording, screenshots, links, or examples that would help.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature request
+description: Suggest a new feature or behavior change.
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What are you trying to do, and why is the current behavior not enough?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Firmware
+        - Amiibo Emulator
+        - Amiibo Database
+        - AmiiboLink
+        - Card Emulator
+        - BLE File Transfer
+        - Web page
+        - Documentation
+        - Hardware
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior you would like to see.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional workarounds or other approaches you have considered.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/support_question.yml
+++ b/.github/ISSUE_TEMPLATE/support_question.yml
@@ -1,7 +1,7 @@
 name: Support question
 description: Ask for help with updates, recovery, BLE, hardware, or usage.
 title: "[Support] "
-labels: ["question"]
+labels: ["question", "support"]
 body:
   - type: dropdown
     id: topic

--- a/.github/ISSUE_TEMPLATE/support_question.yml
+++ b/.github/ISSUE_TEMPLATE/support_question.yml
@@ -1,0 +1,60 @@
+name: Support question
+description: Ask for help with updates, recovery, BLE, hardware, or usage.
+title: "[Support] "
+labels: ["question"]
+body:
+  - type: dropdown
+    id: topic
+    attributes:
+      label: Topic
+      options:
+        - Firmware update / DFU
+        - Wrong LCD/OLED firmware
+        - Blank or garbled screen
+        - BLE File Transfer
+        - Amiibo Database
+        - Amiibo Emulator
+        - AmiiboLink
+        - Card Emulator
+        - Hardware build
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: firmware-version
+    attributes:
+      label: Firmware version
+      placeholder: "Example: 2.13.0, unknown, cannot see the screen"
+    validations:
+      required: true
+  - type: dropdown
+    id: target
+    attributes:
+      label: Hardware target
+      options:
+        - LCD
+        - OLED
+        - Not sure
+    validations:
+      required: true
+  - type: input
+    id: hardware-source
+    attributes:
+      label: Hardware/vendor
+      placeholder: "Example: self-built, Taobao kit, AliExpress, Wuzplay, unknown"
+    validations:
+      required: true
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: Describe what you are trying to do and where you are stuck.
+    validations:
+      required: true
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you already tried?
+      description: Include apps, browsers, firmware files, docs, screenshots, or photos if available.
+    validations:
+      required: false

--- a/.github/ISSUE_TRIAGE.md
+++ b/.github/ISSUE_TRIAGE.md
@@ -1,0 +1,109 @@
+# Issue Triage Proposal
+
+This document proposes a lightweight issue triage workflow for maintainers. The
+goal is to close answered issues with clear comments, keep open issues easier to
+sort, and avoid labels that duplicate GitHub's built-in PR linking.
+
+## Labels
+
+Use the existing default labels where possible:
+
+- `bug`
+- `documentation`
+- `duplicate`
+- `enhancement`
+- `good first issue`
+- `help wanted`
+- `invalid`
+- `question`
+
+Suggested additional labels:
+
+- `support`: usage, update, recovery, BLE, or device-specific help.
+- `needs-info`: missing firmware version, LCD/OLED target, hardware/vendor,
+  reproduction steps, logs, or photos.
+- `blocked`: waiting on hardware, release, maintainer decision, or external
+  confirmation.
+- `release-needed`: fixed in code or a pull request, but not yet shipped in a
+  release.
+- `area: docs`
+- `area: firmware`
+- `area: web`
+- `area: amiidb`
+- `area: nfc`
+- `area: ui`
+- `area: hardware/vendor`
+
+`has-pr` is intentionally not included. GitHub already links issues and pull
+requests through references, closing keywords, and timeline events.
+
+`wontfix` should only be used when maintainers explicitly decide that something
+will not be supported. For normal triage, prefer `support`, `duplicate`,
+`invalid`, `needs-info`, or a clear closing comment.
+
+## Closing Policy
+
+Before closing an issue, leave a short comment explaining why it is being closed
+and what the user should provide if the problem still exists.
+
+Suggested comment for issues resolved by documentation or code:
+
+```markdown
+This should now be covered by the updated documentation in #PR.
+
+I am going to close this as answered/documented. If the issue is still
+reproducible on the latest firmware, please open a new bug report with the
+firmware version, LCD/OLED target, hardware/vendor, and reproduction steps.
+```
+
+Suggested comment for duplicates:
+
+```markdown
+This appears to be covered by #CANONICAL_ISSUE / #PR, so I am closing this one
+as duplicate to keep the discussion in one place.
+```
+
+Suggested comment for support/vendor-specific cases:
+
+```markdown
+This looks specific to a third-party/vendor firmware or device variant, so it is
+outside the current upstream firmware scope. Closing as support/vendor-specific.
+```
+
+## Current Triage Waves
+
+Wave 1 closes issues already covered by merged or open pull requests:
+
+| Issue | Action |
+| --- | --- |
+| #225 | Close as duplicate/already answered by #219; #439 fixed a separate LFS-only directory rename bug found during investigation. |
+| #267 | Close after #441 merges; wrong LCD/OLED firmware recovery is documented there. |
+| #369 | Close as fixed by #436; invalid `settings.bin` can now be recovered and saved again. |
+| #400 | Close after #440 merges if the Amiibo DB source change is accepted. |
+| #408 | Close after #437 merges; long Amiibo description auto-scroll is implemented there. |
+| #422 | Close after #428 merges; sequential NFC scan freeze hardening is implemented there. |
+| #423 | Close as support/vendor-specific if maintainers agree this device variant is outside upstream scope. |
+
+Wave 2 should be handled by small documentation pull requests:
+
+1. Firmware update and recovery troubleshooting.
+2. Card emulator, files, dumps, and backup behavior.
+3. README project identity and Amiibo DB source clarification.
+4. Issue templates for bug reports, support, feature requests, and documentation.
+
+## Helper Script
+
+Maintainers can preview the proposed label and issue actions with:
+
+```sh
+python3 .github/scripts/apply_issue_triage.py --repo solosky/pixl.js
+```
+
+Apply the actions with:
+
+```sh
+python3 .github/scripts/apply_issue_triage.py --repo solosky/pixl.js --apply
+```
+
+The script is dry-run by default, skips actions that depend on unmerged pull
+requests, and avoids posting the same managed comment twice.

--- a/.github/scripts/apply_issue_triage.py
+++ b/.github/scripts/apply_issue_triage.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Apply the proposed Pixl.js issue triage actions.
+
+The script is intentionally conservative:
+- dry-run is the default;
+- labels are created only when applying;
+- issue actions that depend on an unmerged PR are skipped;
+- managed comments include a marker so they are not posted twice.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+
+LABELS: dict[str, dict[str, str]] = {
+    "support": {
+        "color": "5319e7",
+        "description": "Usage, update, recovery, BLE, or device-specific support",
+    },
+    "needs-info": {
+        "color": "d4c5f9",
+        "description": "More details are required before this can be acted on",
+    },
+    "blocked": {
+        "color": "b60205",
+        "description": "Blocked by release, hardware, external confirmation, or maintainer decision",
+    },
+    "release-needed": {
+        "color": "fbca04",
+        "description": "Fixed in code or PR, but not yet available in a release",
+    },
+    "area: docs": {
+        "color": "0075ca",
+        "description": "Documentation, guides, or issue templates",
+    },
+    "area: firmware": {
+        "color": "0e8a16",
+        "description": "Firmware behavior or device-side code",
+    },
+    "area: web": {
+        "color": "1d76db",
+        "description": "Web tools or browser-based update/file transfer flows",
+    },
+    "area: amiidb": {
+        "color": "c2e0c6",
+        "description": "Amiibo database, generated data, or Amiibo metadata",
+    },
+    "area: nfc": {
+        "color": "bfd4f2",
+        "description": "NFC scanning, emulation, or tag behavior",
+    },
+    "area: ui": {
+        "color": "f9d0c4",
+        "description": "Device UI, display, menus, and text rendering",
+    },
+    "area: hardware/vendor": {
+        "color": "d93f0b",
+        "description": "Hardware revisions, kits, or vendor-specific device variants",
+    },
+}
+
+
+@dataclass(frozen=True)
+class IssueAction:
+    number: int
+    labels: tuple[str, ...]
+    comment: str | None = None
+    close: bool = False
+    state_reason: str = "completed"
+    requires_pr: int | None = None
+
+    @property
+    def marker(self) -> str:
+        return f"<!-- pixl-issue-triage:{self.number} -->"
+
+
+ISSUE_ACTIONS: tuple[IssueAction, ...] = (
+    IssueAction(
+        number=225,
+        labels=("duplicate",),
+        close=True,
+        state_reason="duplicate",
+        comment="""This appears to be covered by #219, so I am closing this one as a duplicate to keep the discussion in one place.
+
+The separate LFS-only directory rename bug found during investigation was handled in #439.""",
+    ),
+    IssueAction(
+        number=267,
+        labels=("support", "area: docs"),
+        close=True,
+        requires_pr=441,
+        comment="""This should now be covered by the updated wrong-firmware recovery documentation in #441.
+
+I am going to close this as answered/documented. If the issue is still reproducible on the latest firmware, please open a new bug report with the firmware version, LCD/OLED target, hardware/vendor, and reproduction steps.""",
+    ),
+    IssueAction(
+        number=369,
+        labels=("bug", "area: firmware", "release-needed"),
+        close=True,
+        comment="""This should be fixed by #436.
+
+The firmware now recovers an invalid `settings.bin` by resetting it and saving a valid default file again, so settings such as language should persist normally after that recovery path runs.
+
+I am going to close this as fixed. If it is still reproducible on the latest firmware, please open a new bug report with the firmware version, LCD/OLED target, hardware/vendor, and reproduction steps.""",
+    ),
+    IssueAction(
+        number=400,
+        labels=("documentation", "area: amiidb"),
+        close=True,
+        requires_pr=440,
+        comment="""This should be covered by the Amiibo database source update in #440.
+
+I am going to close this as fixed/documented. If the database source breaks again, please open a new issue with the failing source URL and generator output.""",
+    ),
+    IssueAction(
+        number=408,
+        labels=("enhancement", "area: amiidb", "area: ui"),
+        close=True,
+        requires_pr=437,
+        comment="""This should be implemented by #437, which adds auto-scroll for long Amiibo descriptions.
+
+I am going to close this as completed. If a specific description still does not scroll correctly on the latest firmware, please open a new bug report with the firmware version, LCD/OLED target, and the Amiibo entry name.""",
+    ),
+    IssueAction(
+        number=422,
+        labels=("bug", "area: nfc"),
+        close=True,
+        requires_pr=428,
+        comment="""This should be fixed by #428, which hardens NFC buffer/page bounds during sequential scans.
+
+I am going to close this as fixed. If it is still reproducible on the latest firmware, please open a new bug report with the firmware version, LCD/OLED target, and the exact scan sequence.""",
+    ),
+    IssueAction(
+        number=423,
+        labels=("support", "area: hardware/vendor"),
+        close=True,
+        comment="""This looks specific to a third-party/vendor firmware or device variant, so it is outside the current upstream firmware scope.
+
+I am closing this as support/vendor-specific. If it is reproducible on the upstream Pixl.js firmware and supported hardware target, please open a new bug report with the firmware version, LCD/OLED target, hardware/vendor, and reproduction steps.""",
+    ),
+)
+
+
+def run_gh(args: list[str], payload: dict[str, Any] | None = None) -> Any:
+    cmd = ["gh", "api", *args]
+    stdin = json.dumps(payload) if payload is not None else None
+    result = subprocess.run(cmd, input=stdin, text=True, capture_output=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"{' '.join(cmd)} failed with exit code {result.returncode}\n"
+            f"stdout: {result.stdout.strip()}\n"
+            f"stderr: {result.stderr.strip()}"
+        )
+    output = result.stdout.strip()
+    return json.loads(output) if output else None
+
+
+def gh_get(endpoint: str) -> Any:
+    return run_gh([endpoint])
+
+
+def gh_post(endpoint: str, payload: dict[str, Any]) -> Any:
+    return run_gh(["-X", "POST", endpoint, "--input", "-"], payload)
+
+
+def gh_patch(endpoint: str, payload: dict[str, Any]) -> Any:
+    return run_gh(["-X", "PATCH", endpoint, "--input", "-"], payload)
+
+
+def print_action(apply: bool, message: str) -> None:
+    prefix = "APPLY" if apply else "DRY-RUN"
+    print(f"[{prefix}] {message}")
+
+
+def ensure_labels(repo: str, apply: bool) -> None:
+    existing = {label["name"] for label in gh_get(f"repos/{repo}/labels?per_page=100")}
+    for name, spec in LABELS.items():
+        if name in existing:
+            print_action(apply, f"label exists: {name}")
+            continue
+
+        print_action(apply, f"create label: {name}")
+        if apply:
+            gh_post(
+                f"repos/{repo}/labels",
+                {"name": name, "color": spec["color"], "description": spec["description"]},
+            )
+
+
+def is_pr_merged(repo: str, pr_number: int) -> bool:
+    pr = gh_get(f"repos/{repo}/pulls/{pr_number}")
+    return bool(pr.get("merged_at"))
+
+
+def managed_comment_exists(repo: str, action: IssueAction) -> bool:
+    comments = gh_get(f"repos/{repo}/issues/{action.number}/comments?per_page=100")
+    return any(action.marker in comment.get("body", "") for comment in comments)
+
+
+def apply_issue_action(repo: str, action: IssueAction, apply: bool, include_pending_prs: bool) -> None:
+    if action.requires_pr is not None and not is_pr_merged(repo, action.requires_pr):
+        message = f"skip #{action.number}: requires merged PR #{action.requires_pr}"
+        if include_pending_prs:
+            message += " (override enabled)"
+        else:
+            print_action(apply, message)
+            return
+
+    if action.labels:
+        print_action(apply, f"add labels to #{action.number}: {', '.join(action.labels)}")
+        if apply:
+            gh_post(f"repos/{repo}/issues/{action.number}/labels", {"labels": list(action.labels)})
+
+    if action.comment:
+        body = f"{action.marker}\n{action.comment}"
+        if managed_comment_exists(repo, action):
+            print_action(apply, f"skip comment on #{action.number}: managed comment already exists")
+        else:
+            print_action(apply, f"comment on #{action.number}")
+            if apply:
+                gh_post(f"repos/{repo}/issues/{action.number}/comments", {"body": body})
+
+    if action.close:
+        print_action(apply, f"close #{action.number} as {action.state_reason}")
+        if apply:
+            gh_patch(
+                f"repos/{repo}/issues/{action.number}",
+                {"state": "closed", "state_reason": action.state_reason},
+            )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default="solosky/pixl.js", help="Repository in owner/name form")
+    parser.add_argument("--apply", action="store_true", help="Apply changes. Default is dry-run.")
+    parser.add_argument(
+        "--only",
+        choices=("all", "labels", "issues"),
+        default="all",
+        help="Limit the operation scope",
+    )
+    parser.add_argument(
+        "--issue",
+        action="append",
+        type=int,
+        default=[],
+        help="Limit issue actions to one issue number. Can be repeated.",
+    )
+    parser.add_argument(
+        "--include-pending-prs",
+        action="store_true",
+        help="Do not skip issue actions that depend on unmerged PRs",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    selected_issues = set(args.issue)
+
+    try:
+        if args.only in {"all", "labels"}:
+            ensure_labels(args.repo, args.apply)
+
+        if args.only in {"all", "issues"}:
+            for action in ISSUE_ACTIONS:
+                if selected_issues and action.number not in selected_issues:
+                    continue
+                apply_issue_action(args.repo, action, args.apply, args.include_pending_prs)
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    if not args.apply:
+        print("\nDry-run complete. Re-run with --apply to mutate GitHub.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/apply_issue_triage.py
+++ b/.github/scripts/apply_issue_triage.py
@@ -194,7 +194,7 @@ def print_action(apply: bool, message: str) -> None:
 
 
 def ensure_labels(repo: str, apply: bool) -> None:
-    existing = {label["name"] for label in gh_get(f"repos/{repo}/labels?per_page=100")}
+    existing = {label["name"] for label in gh_get_paginated(f"repos/{repo}/labels?per_page=100")}
     for name, spec in LABELS.items():
         if name in existing:
             print_action(apply, f"label exists: {name}")
@@ -223,6 +223,7 @@ def apply_issue_action(repo: str, action: IssueAction, apply: bool, include_pend
         message = f"skip #{action.number}: requires merged PR #{action.requires_pr}"
         if include_pending_prs:
             message += " (override enabled)"
+            print_action(apply, message)
         else:
             print_action(apply, message)
             return

--- a/.github/scripts/apply_issue_triage.py
+++ b/.github/scripts/apply_issue_triage.py
@@ -103,6 +103,7 @@ I am going to close this as answered/documented. If the issue is still reproduci
         number=369,
         labels=("bug", "area: firmware", "release-needed"),
         close=True,
+        requires_pr=436,
         comment="""This should be fixed by #436.
 
 The firmware now recovers an invalid `settings.bin` by resetting it and saving a valid default file again, so settings such as language should persist normally after that recovery path runs.
@@ -165,6 +166,20 @@ def gh_get(endpoint: str) -> Any:
     return run_gh([endpoint])
 
 
+def gh_get_paginated(endpoint: str) -> list[Any]:
+    items: list[Any] = []
+    separator = "&" if "?" in endpoint else "?"
+    page = 1
+    while True:
+        page_items = gh_get(f"{endpoint}{separator}page={page}")
+        if not isinstance(page_items, list):
+            raise RuntimeError(f"Expected a list response from paginated endpoint: {endpoint}")
+        items.extend(page_items)
+        if len(page_items) < 100:
+            return items
+        page += 1
+
+
 def gh_post(endpoint: str, payload: dict[str, Any]) -> Any:
     return run_gh(["-X", "POST", endpoint, "--input", "-"], payload)
 
@@ -199,7 +214,7 @@ def is_pr_merged(repo: str, pr_number: int) -> bool:
 
 
 def managed_comment_exists(repo: str, action: IssueAction) -> bool:
-    comments = gh_get(f"repos/{repo}/issues/{action.number}/comments?per_page=100")
+    comments = gh_get_paginated(f"repos/{repo}/issues/{action.number}/comments?per_page=100")
     return any(action.marker in comment.get("body", "") for comment in comments)
 
 


### PR DESCRIPTION
## Summary

This PR proposes a lightweight issue triage workflow and adds structured issue templates.

It includes:

- `.github/ISSUE_TRIAGE.md` with suggested labels, closing policy, and the current triage waves.
- Issue forms for bug reports, support questions, feature requests, and documentation requests.
- `.github/scripts/apply_issue_triage.py`, a dry-run-first helper script for maintainers to preview/apply the suggested labels, comments, and issue closures.

The script intentionally does not use a `has-pr` label, and it treats `wontfix` as a maintainer-only decision rather than a normal triage label.

## Safety

The helper script is conservative by default:

- dry-run unless `--apply` is passed;
- creates proposed labels only while applying;
- skips issue actions that depend on unmerged PRs;
- adds hidden markers to managed comments so it does not post the same managed comment twice.

## Validation

- YAML issue forms parsed successfully
- Python script compiled successfully
- `python3 .github/scripts/apply_issue_triage.py --repo solosky/pixl.js` dry-run completed successfully
- `git diff --cached --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guided GitHub issue forms for bug reports, feature requests, support questions, and documentation requests.
  * Added a community Discord contact link for support.

* **Chores**
  * Published an issue triage guide to standardize labels, closing policies, and responder templates.
  * Introduced a conservative triage automation tool to assist maintainers with labeling, commenting, and closing workflows (dry-run by default).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->