### PR TITLE
docs: clarify firmware OTA zip and card dump imports

### DIFF
--- a/docs/en/02-Flash-Firmware.md
+++ b/docs/en/02-Flash-Firmware.md
@@ -38,7 +38,8 @@ On iOS, The firmware is `pixjs_ota_vxxx.zip` in the compressed package and needs
 On Android you can use the DFU icon on the upper right of the screen, Select the `Distribution packet (ZIP)` option and browse your storage for the `pixjs_ota_vxxx.zip` file.
 
 ### Web page method
-Download the latest version of the firmware zip package correspondent to your device version, and extract it to a directory.
+Download the latest version of the firmware zip package corresponding to your device version, and extract it to a directory.
+The release package is an outer zip file for your hardware version. Do not upload that outer zip file to the DFU updater. After extracting it, use the inner OTA package named `pixjs_ota_vxxx.zip`. Uploading the outer release zip can cause errors such as `Unable to find manifest` or `init not found`.
 
 The project provide two ways to achive a DFU update:
 
@@ -50,7 +51,7 @@ Also you can go directly to the Firmware Update Page.
 
 First you need to put your pixl.js device on "Firmware Update" mode.  To do so, select the `Settings` app and select the item `Firmware Update`.
 
-Open the [firmware update page](https://thegecko.github.io/web-bluetooth-dfu).  Drag and drop or select `pixljs_ota_xxx.zip` file from the folder where you extract the firmware package.
+Open the [firmware update page](https://thegecko.github.io/web-bluetooth-dfu).  Drag and drop or select the inner `pixjs_ota_vxxx.zip` file from the folder where you extracted the firmware package.
 
 Then press the `SELECT DEVICE` button on the page you should see a device called `pixl dfu` connect to start the firmware upgrade process.
 

--- a/docs/en/04-Using-Firmware.md
+++ b/docs/en/04-Using-Firmware.md
@@ -375,13 +375,15 @@ In this interface, you can perform the import and export of card data.
 |   |
 
 The import and export files are stored in the `/chameleon/dump/` folder.<br />
-If you need to import data, you need to write the data file you want to import to the above folder through the webpage in advance.
+If you need to import data, write the data file you want to import to that folder through the webpage in advance.
+
+Import files must be raw binary card dumps, not text or hex export files. The loader lists regular files from `/chameleon/dump/`, so the filename extension is only for your own organization; for example, `.dump` and `.bin` can both work if the file content is raw binary data. A file exported with `Save` is a good example of the expected format.
 
 * Load: Pressing the middle button allows you to enter the load interface. The interface will read all files under `/chameleon/dump/`, and pressing the middle button can perform the import.
 * Save: Pressing the middle button allows you to export the current card to the `/chameleon/dump/` folder.
 * Factory: Pressing the middle button allows you to reset the current card data to the default built-in empty card data.
 
-> The file size loaded must be exactly the same as the current card type to be imported. The data file size for different cards refers to the table in the `Card Emulation`.
+> The file size loaded must be exactly the same as the current card type to be imported. For example, an NTAG 215 dump must be 540 bytes and a Mifare 1K dump must be 1024 bytes. The data file size for each card type is listed in the table in `Card Emulation`.
 
 
 ## Advanced


### PR DESCRIPTION
## Summary
- clarify that firmware OTA updates must use the inner `pixjs_ota_vxxx.zip` package, not the outer hardware release zip
- document the common `Unable to find manifest` / `init not found` symptom when the wrong zip is uploaded
- explain that Card Emulator imports are raw binary dumps and must match the selected card type size exactly

## Why
Users can easily pick the outer release zip when updating firmware, which makes DFU tools report missing manifest/init errors. The Card Emulator docs also did not clearly state what dump format is expected for imports.

Closes #302
Closes #354

## Validation
- `git diff --check`
- `rg -n "pixljs_ota|pixjs_ota" docs/en/02-Flash-Firmware.md`
- Docs-only change; firmware build not run.