### PR TITLE
docs: clarify hardware variants

### DIFF
--- a/docs/en/00-Buyer-Guide.md
+++ b/docs/en/00-Buyer-Guide.md
@@ -1,0 +1,36 @@
+# Buyer Guide and Hardware Variants
+
+The pixl.js firmware in this repository targets the open pixl.js hardware variants documented here. Before updating a device bought from a marketplace, identify the exact hardware variant and use the matching firmware package.
+
+## Official release packages
+
+Release assets are split by hardware version:
+
+| Device hardware | Release package to use |
+| --- | --- |
+| LCD pixl.js / allmiibo-compatible hardware with the three-way thumbwheel control | `*_LCD.zip` |
+| OLED pixl.js hardware with the same three-way thumbwheel control | `*_OLED.zip` |
+
+After downloading the correct outer release package, extract it and use the inner `pixjs_ota_vxxx.zip` file for OTA updates.
+
+## Modified or rebranded devices
+
+Some devices are sold with pixl.js-like names, iNFC/AmiiboTool firmware, extra buttons, a different button layout, or a different screen orientation. Those devices may not be compatible with the LCD or OLED release packages from this repository.
+
+Common signs of an incompatible package include:
+
+- the screen is upside down;
+- the back button or side buttons do not match the firmware;
+- the screen shows stripes, a garbled image, or only the backlight;
+- the device works with a vendor firmware package but not with the standard pixl.js LCD/OLED package.
+
+This does not necessarily mean the device is broken. It usually means the hardware needs a different board definition, display orientation, button map, or vendor firmware package. Support for a new variant requires hardware details and test feedback; it cannot be safely selected from the screen type alone.
+
+## Before updating
+
+- Keep a copy of the firmware package that came with the device or was provided by the seller.
+- Check whether the device is the documented LCD/OLED pixl.js hardware or a modified AmiiboTool/iNFC-style variant.
+- If the device has extra buttons or a different case layout, do not assume the standard LCD/OLED release package is compatible.
+- If you are unsure, ask for the exact device variant before flashing.
+
+If the wrong or incompatible firmware was already installed, see the firmware flashing and recovery guide in [Flash the Firmware](02-Flash-Firmware.md).

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -1,13 +1,18 @@
 
 # **Welcome to the pixl.js project documentation !**
 
-The pixl.jx project is a forked version of the original [Pixl.js](http://www.espruino.com/Pixl.js). The main focus of this fork is to simulate Amiibo.
+The pixl.js project is inspired by the original [Espruino Pixl.js](http://www.espruino.com/Pixl.js) board. This firmware is focused on Amiibo and NFC emulation and is implemented as native C firmware, not as the stock Espruino JavaScript runtime.
+
+The name comes from the early hardware work: the original Espruino Pixl.js board was close to the device shape needed for Amiibo emulation, so this project kept the pixl.js name while changing the PCB, adding storage, and building a dedicated firmware.
+
+If you want to run your own JavaScript code, use the original Espruino Pixl.js hardware/firmware or a compatible Espruino build. The release packages from this repository are for the Amiibo-focused pixl.js firmware.
 
 This fork is divided in two main sections, Hardware and Firmware
 
 
 # [Hardware](01-Hardware.md)
 
+- [Buyer guide and hardware variants](00-Buyer-Guide.md)
 - [PCB](01-Hardware.md#PCB)
 - [BOM](01-Hardware.md#BOM)
 - [Pictures](01-Hardware.md#Pictures)


### PR DESCRIPTION
## Summary
- clarify that this project is an Amiibo-focused native C firmware inspired by the original Espruino Pixl.js board, not the stock Espruino runtime
- add a buyer guide for LCD/OLED packages, modified devices, and AmiiboTool/iNFC-style variants
- document symptoms that usually indicate an incompatible hardware package, such as upside-down screen, broken buttons, or mismatched orientation

Closes #296
Closes #393

## Test plan
- `git diff --check -- docs/en/README.md docs/en/00-Buyer-Guide.md`
- docs-only change; no firmware build run