### PR TITLE
docs: add firmware app overview

### DIFF
--- a/docs/en/04-Using-Firmware.md
+++ b/docs/en/04-Using-Firmware.md
@@ -44,8 +44,6 @@ The Pixl.js firmware Main Screen is divided on several Applications, each one ca
 | --- | --- |
 | Amiibo Emulator | Browsing `.BIN` amiibo files stored on the device and emulating one selected file. |
 | Amiibo Database | Selecting an amiibo from the built-in database and creating a virtual tag from its model data. This requires `key_retail.bin`. |
-| My Favorites | Organizing database entries into folders for quicker browsing. Favorites are shortcuts to database entries. |
-| My Amiibo | Keeping a fixed set of database amiibo slots for fast selection. This is different from Favorites, which are folder-based. |
 | AmiiboLink | Emulating an AmiiboLink, AmiLoop, or omllbolink-style Bluetooth device for compatible phone apps. |
 | Card Emulator | Emulating supported Mifare and NTAG cards from raw card dump data. This is the Chameleon-style card emulator feature, not the amiibo emulator. |
 | BLE File Transfer | Connecting to the pixl.js web page or iNFC app to manage files or enter firmware update mode. |

--- a/docs/en/04-Using-Firmware.md
+++ b/docs/en/04-Using-Firmware.md
@@ -38,6 +38,19 @@ The Pixl.js firmware Main Screen is divided on several Applications, each one ca
 |  Amiibo Emulator<br> Amiibo Database<br>֍ AmiiboLink<br>ᛡᛒ  BLE File Transfer<br> Settings |
 |   |
 
+## Which application should I use?
+
+| Application | Use it for |
+| --- | --- |
+| Amiibo Emulator | Browsing `.BIN` amiibo files stored on the device and emulating one selected file. |
+| Amiibo Database | Selecting an amiibo from the built-in database and creating a virtual tag from its model data. This requires `key_retail.bin`. |
+| My Favorites | Organizing database entries into folders for quicker browsing. Favorites are shortcuts to database entries. |
+| My Amiibo | Keeping a fixed set of database amiibo slots for fast selection. This is different from Favorites, which are folder-based. |
+| AmiiboLink | Emulating an AmiiboLink, AmiLoop, or omllbolink-style Bluetooth device for compatible phone apps. |
+| Card Emulator | Emulating supported Mifare and NTAG cards from raw card dump data. This is the Chameleon-style card emulator feature, not the amiibo emulator. |
+| BLE File Transfer | Connecting to the pixl.js web page or iNFC app to manage files or enter firmware update mode. |
+| Settings | Changing firmware options such as language, display contrast, backlight, battery mode, sleep timeout, and app visibility. |
+
 ----
 # Amiibo Emulator
 This application allows you to browse local storage for .BIN files and use them as the current amiibo.
@@ -152,6 +165,8 @@ Allows to search the database using partial name, the search result is like a ca
 ## My Favorites…
 Display the existent favorites folders, you can browse them with side buttons and select one with middle button.  If you press and Hold the middle button a sub menu is open:
 
+Favorites are folders of shortcuts to amiibo from the built-in database. Use them when you want to group many database entries, for example by game or by the figures you use most often.
+
 |   |
 | ------------ |
 | New…<BR>Empty…<BR>Delete…<BR>[Back] |
@@ -170,6 +185,8 @@ Once you select a folder a list of the associated amiibo to that favorite folder
 
 ## My Amiibo…
 List the configured slots, you can browse the slots using side buttons, select one with middle button and the amiibo associated to that slot becomes the current one.
+
+My Amiibo is a small fixed slot list for quick access to selected database amiibo. Use it when you want a short rotation of frequently used amiibo without browsing favorite folders.
 
 If you press and hold middle button a sub menu with the option of reset the slot is shown allowing to empty the slot.
 
@@ -247,7 +264,7 @@ Other oddity is what the modes on applications do not correspond with the modes 
 
 # Card Emulator
 
-This application can be used to emulate Mifare cards and NTAG series cards.
+This application can be used to emulate Mifare cards and NTAG series cards. It is based on the Chameleon-style card emulation feature and is separate from Amiibo Emulator and Amiibo Database.
 
 Mifare cards are commonly used for access control cards, and the device can fully emulate Mifare types of cards. Supported Mifare card types include:
 
@@ -509,7 +526,9 @@ With this setting you can control the brightness of the LCD screen or the contra
 ## Menu Animation
 Enable / disable the animation of items larger than screen allowing to read them completely, enabling this option increase the battery consumption.
 ## LiPO Battery
-Enable the use of a LiPO battery.  It requires an hardware mod. If you build a LiPO version of Pixl.js device, you can enable this option. For CR2032 version, this option will not work and should not be enabled.
+Enable the LiPO battery voltage profile. It requires hardware with a rechargeable LiPO battery connected to the expected battery sensing and charging circuit. This option does not add charging support by itself.
+
+Some OLED devices are sold with a rechargeable battery, but OLED alone does not prove that the board matches the LiPO hardware expected by this firmware. If the device uses a CR2032 cell, or if you are not sure how the battery circuit is wired, leave this option disabled.
 
 If you enable LiPO option, the device will use LiPO voltage level to display the battery level, and also can display a charge label when the battery is in charge mode.
 ## Memory Used


### PR DESCRIPTION
## Summary
- add a quick overview table explaining which firmware app to use for each task
- clarify the difference between Favorites and My Amiibo
- explain that Card Emulator is the Chameleon-style card feature, separate from Amiibo emulation
- clarify that the LiPO battery option requires matching rechargeable-battery hardware and does not add charging support by itself

Closes #280

## Test plan
- `git diff --check -- docs/en/04-Using-Firmware.md`
- docs-only change; no firmware build run