### PR TITLE
docs: clarify Wolf Link save data behavior

### DIFF
--- a/docs/en/04-Using-Firmware.md
+++ b/docs/en/04-Using-Firmware.md
@@ -102,6 +102,8 @@ This application allows the emulation of amiibo from the list of well know ones,
 
 _Each time one an amiibo is used the initial UUID is random generated._
 
+The database creates virtual tags from amiibo model data. Effects that depend on savedata or the encrypted application area, such as a 20-heart Wolf Link in Breath of the Wild, are not included in the database entry. To use that kind of savedata-dependent behavior, use Amiibo Emulator with your own legally acquired `.BIN` dump.
+
 Once you open the application the main menu have the options
 
 |   |

--- a/fw/application/src/amiidb/db_link.c
+++ b/fw/application/src/amiidb/db_link.c
@@ -53,7 +53,7 @@ const db_link_t link_list[] = {
 {4, 0x01000000, 0x03540902, "Bridle and Saddle/Moonlight Scimitar/Mushroom", "马缰绳&马鞍/月光匕首/蘑菇", "Redini e Sella/Tessuto della Paravela/Scimitarra di Luce/Funghi"}, 
 {4, 0x01000000, 0x034e0902, "Skyward Set/Skyward Sword/Soldier's and Traveler's Sword & Shield/Rupee", "天空勇者服套装/天空剑/士兵&旅人剑盾/卢比", "Set Spada del Cielo/Spada del Cielo/Tessuto della Paravela/Rupie"}, 
 {4, 0x01000000, 0x034d0902, "Twilight Set/Traveler's Sword & Shield/Fruit/Horse", "黄昏服套装/旅人剑&盾/水果/马", "Set Crepuscolo/Spada & Scudo del Viaggiatore/Tessuto della Paravela/Frutto/Cavallo"}, 
-{4, 0x01030000, 0x024f0902, "20 Heart Wolf Link", "20心林克狼", "Link Lupo con 20 Cuori"}, 
+{4, 0x01030000, 0x024f0902, "Wolf Link (hearts depend on save data)", "林克狼（心数取决于保存数据）", "Link Lupo (cuori dipendono dai dati salvati)"},
 {4, 0x01070000, 0x035a0902, "Ruto's Divine Helm/Silver Long Spear/Fish", "露塔*神兽兵装/银鳞之枪/鱼", "Elmo Sacro di Ruta/Tessuto della Paravela/Lancia a Scaglie d'Argento/Pesce"}, 
 {4, 0x01080000, 0x035b0902, "Medoh's Divine Helm/Falcon Bow/Fruit/Diamond", "梅德*神兽兵装/游隼弓/水果 钻石", "Elmo Sacro di Medoh/Tessuto della Paravela/Grande Arco dell'Aquila/Frutto/Diamante"}, 
 {4, 0x01010100, 0x00170002, "Sheik Set/Eightfold Blade/Mushroom", "希克服套装/戒心刀/蘑菇", "Set Sheikah/Tessuto della Paravela/Spadone Curvo/Funghi"}, 

--- a/fw/data/amiidb_link.csv
+++ b/fw/data/amiidb_link.csv
@@ -50,7 +50,7 @@
 4,0100000003540902,Bridle and Saddle/Moonlight Scimitar/Mushroom,马缰绳&马鞍/月光匕首/蘑菇,Redini e Sella/Tessuto della Paravela/Scimitarra di Luce/Funghi
 4,01000000034e0902,Skyward Set/Skyward Sword/Soldier's and Traveler's Sword & Shield/Rupee,天空勇者服套装/天空剑/士兵&旅人剑盾/卢比,Set Spada del Cielo/Spada del Cielo/Tessuto della Paravela/Rupie
 4,01000000034d0902,Twilight Set/Traveler's Sword & Shield/Fruit/Horse,黄昏服套装/旅人剑&盾/水果/马,Set Crepuscolo/Spada & Scudo del Viaggiatore/Tessuto della Paravela/Frutto/Cavallo
-4,01030000024f0902,20 Heart Wolf Link,20心林克狼,Link Lupo con 20 Cuori
+4,01030000024f0902,Wolf Link (hearts depend on save data),林克狼（心数取决于保存数据）,Link Lupo (cuori dipendono dai dati salvati)
 4,01070000035a0902,Ruto's Divine Helm/Silver Long Spear/Fish,露塔*神兽兵装/银鳞之枪/鱼,Elmo Sacro di Ruta/Tessuto della Paravela/Lancia a Scaglie d'Argento/Pesce
 4,01080000035b0902,Medoh's Divine Helm/Falcon Bow/Fruit/Diamond,梅德*神兽兵装/游隼弓/水果 钻石,Elmo Sacro di Medoh/Tessuto della Paravela/Grande Arco dell'Aquila/Frutto/Diamante
 4,0101010000170002,Sheik Set/Eightfold Blade/Mushroom,希克服套装/戒心刀/蘑菇,Set Sheikah/Tessuto della Paravela/Spadone Curvo/Funghi


### PR DESCRIPTION
## Summary
- rename the Breath of the Wild Wolf Link database reward label so it no longer promises a 20-heart result from the generated Amiibo Database entry
- document that savedata/app-area-dependent effects, such as 20-heart Wolf Link, require a legally acquired `.BIN` dump used through Amiibo Emulator
- no raw amiibo dump files are added

## Root cause
The Amiibo Database creates a virtual tag from model data and a random UUID. Breath of the Wild reads Wolf Link hearts from encrypted savedata/application-area data in the tag dump, so the database entry cannot create the 20-heart variant by model ID alone.

Closes #419

## Test plan
- `git diff --check`
- `rg -n "20 Heart Wolf Link|20心林克狼|Link Lupo con 20 Cuori" fw/data fw/application/src/amiidb docs/en/04-Using-Firmware.md` produced no matches
- confirmed `01030000024f0902` uses the new Wolf Link save-data label in `fw/data/amiidb_link.csv` and `fw/application/src/amiidb/db_link.c`
- docs/data-only change; no local firmware build run