### PR TITLE
fix: retain full fast wakeup cache RAM range

### DIFF
--- a/fw/application/src/mod/cache.c
+++ b/fw/application/src/mod/cache.c
@@ -1,5 +1,7 @@
 #include "cache.h"
 
+#include <stdint.h>
+
 #include "ntag_emu.h"
 
 #include "nrf_error.h"
@@ -13,17 +15,64 @@
 #include "settings.h"
 #include "crc32.h"
 
-#define NOINIT_RAM_INDEX 1
+// nRF52 RAM retention is configured per 8 KiB block, split into two 4 KiB sections.
+#define NRF52_RAM_BASE_ADDR 0x20000000UL
+#define NRF52_RAM_POWER_BLOCK_SIZE 0x2000UL
+#define NRF52_RAM_POWER_SECTION_SIZE 0x1000UL
+#define NRF52_RAM_POWER_SECTIONS_PER_BLOCK (NRF52_RAM_POWER_BLOCK_SIZE / NRF52_RAM_POWER_SECTION_SIZE)
 
 
-extern int32_t __start_noinit;
-extern int32_t __stop_noinit;
+extern uint8_t __start_noinit;
+extern uint8_t __stop_noinit;
 
 static __attribute__((section(".noinit"))) cache_data_t m_cache_data;
 static __attribute__((section(".noinit"))) int32_t m_cache_crc32;
 
+static size_t cache_noinit_size() {
+    return (size_t)(&__stop_noinit - &__start_noinit);
+}
+
+static uint32_t cache_ram_retention_mask(uint32_t section) {
+    return POWER_RAM_POWER_S0RETENTION_On << (POWER_RAM_POWER_S0RETENTION_Pos + section);
+}
+
+static ret_code_t cache_enable_noinit_retention() {
+    uintptr_t start = (uintptr_t)&__start_noinit;
+    uintptr_t end = (uintptr_t)&__stop_noinit;
+
+    if (end <= start) {
+        return NRF_SUCCESS;
+    }
+
+    uintptr_t first_offset = start - NRF52_RAM_BASE_ADDR;
+    uintptr_t last_offset = end - NRF52_RAM_BASE_ADDR - 1;
+    uint32_t first_section = first_offset / NRF52_RAM_POWER_SECTION_SIZE;
+    uint32_t last_section = last_offset / NRF52_RAM_POWER_SECTION_SIZE;
+
+    for (uint32_t section = first_section; section <= last_section; section++) {
+        uint8_t ram_index = section / NRF52_RAM_POWER_SECTIONS_PER_BLOCK;
+        uint32_t ram_section = section % NRF52_RAM_POWER_SECTIONS_PER_BLOCK;
+        uint32_t ram_power = 0;
+        uint32_t retention_mask = cache_ram_retention_mask(ram_section);
+
+        ret_code_t err_code = sd_power_ram_power_get(ram_index, &ram_power);
+        if (err_code != NRF_SUCCESS) {
+            return err_code;
+        }
+
+        NRF_LOG_INFO("RAM%d power: 0x%X, retaining S%d", ram_index, ram_power, ram_section);
+        err_code = sd_power_ram_power_set(ram_index, retention_mask);
+        if (err_code != NRF_SUCCESS) {
+            return err_code;
+        }
+    }
+
+    return NRF_SUCCESS;
+}
+
 bool cache_valid(){
-    NRF_LOG_INFO("noinit area: [0x%X, 0x%X], %d bytes",  &__start_noinit, &__stop_noinit, (&__stop_noinit - &__start_noinit));
+    NRF_LOG_INFO("noinit area: [0x%X, 0x%X], %u bytes",  &__start_noinit, &__stop_noinit,
+                 (uint32_t)cache_noinit_size());
     NRF_LOG_INFO("m_cache_data address: 0x%X", &m_cache_data);
     return m_cache_crc32 == crc32_compute((const int8_t *)&m_cache_data, sizeof(cache_data_t), NULL);
 }
@@ -31,8 +80,8 @@ bool cache_valid(){
 int32_t cache_clean() {
     NRF_LOG_INFO("Cleaning cache...")
     // 重置一下noinit ram区域
-    uint32_t *noinit_addr = &__start_noinit;
-    size_t noinit_size = (&__stop_noinit - &__start_noinit);
+    uint8_t *noinit_addr = &__start_noinit;
+    size_t noinit_size = cache_noinit_size();
     memset(noinit_addr, 0x0, noinit_size);
     m_cache_crc32 = crc32_compute(&m_cache_data, sizeof(cache_data_t), NULL);
 
@@ -45,12 +94,10 @@ int32_t cache_save() {
     m_cache_crc32 = crc32_compute(&m_cache_data, sizeof(cache_data_t), NULL);
     NRF_LOG_INFO("Cache data: enabled = %d, id = %d", m_cache_data.enabled, m_cache_data.id);
 
-    //set ram retention
-    uint32_t ram1_power = 0;
-    sd_power_ram_power_get(NOINIT_RAM_INDEX, &ram1_power);
-    NRF_LOG_INFO("RAM1 power: 0x%X", ram1_power);
-    ram1_power = POWER_RAM_POWER_S0RETENTION_On << POWER_RAM_POWER_S0RETENTION_Pos;
-    sd_power_ram_power_set(NOINIT_RAM_INDEX, ram1_power);
+    ret_code_t err_code = cache_enable_noinit_retention();
+    if (err_code != NRF_SUCCESS) {
+        return err_code;
+    }
 
     return NRF_SUCCESS;
 }


### PR DESCRIPTION
## Summary
- replace the fixed `RAM1/S0` retention setup with retention based on the actual `.noinit` address range
- retain every nRF52 RAM section touched by the fast wakeup cache
- preserve the existing cache CRC/state flow while making the retention setup resilient to future `.noinit` growth

## Root Cause
`Fast Wakeup` stores app/cache state in the `.noinit` region and validates it with a CRC after wakeup. Older firmware kept this region within `RAM1/S0`, and `cache_save()` only enabled `S0RETENTION` for RAM block 1.

After NTAG I2C 2K support increased `ntag_t`, `.noinit` grew from `0x430` to `0xA30` bytes and now spans both `RAM1/S0` and `RAM1/S1`. Since `S1RETENTION` was not enabled, part of the cache could be lost during System OFF wakeup, making `cache_valid()` fail and causing the launcher to return to the desktop instead of restoring Amiibo Emulator/AmiiboLink state.

This PR computes the RAM block/section range from `__start_noinit` and `__stop_noinit`, then enables retention for every section used by `.noinit`. That should fix the current `S1` case without hard-coding a temporary `S1RETENTION` workaround.

Closes #426

## Test Plan
- `git diff --check origin/develop...HEAD`
- inspected the linker range: current `.noinit` starts at `0x20002bd0` and length `0xA30`, so it crosses from `RAM1/S0` into `RAM1/S1`
- local firmware build attempted but blocked by local SDK/toolchain setup: missing vendored `external/mbedtls` sources/includes and `arm-none-eabi-gcc` could not find `stdint.h`

## Hardware Validation Needed
Please validate on LCD firmware with Fast Wakeup enabled:
- open Amiibo Emulator or AmiiboLink
- let the device sleep
- wake it with the button
- confirm it resumes the previous app/state instead of returning to the desktop