### PR TITLE
fix: save Amiibo Database slots with tag size

### DIFF
--- a/fw/application/src/app/amiidb/api/amiidb_api_slot.c
+++ b/fw/application/src/app/amiidb/api/amiidb_api_slot.c
@@ -3,11 +3,25 @@
 //
 #include "amiidb_api_slot.h"
 #include "amiibo_helper.h"
+#include "db_header.h"
 #include "settings.h"
 #include "vfs.h"
 #include "vfs_meta.h"
 #include <stdio.h>
 #include <string.h>
+
+static ntag_type_t amiidb_api_slot_get_tag_type(int32_t size, vfs_meta_t *meta, ntag_t *p_ntag) {
+    if (size == NTAG_I2C_2K_DATA_SIZE) {
+        uint32_t head = meta->has_amiibo_id ? meta->amiibo_head : to_little_endian_int32(&p_ntag->data[84]);
+        uint32_t tail = meta->has_amiibo_id ? meta->amiibo_tail : to_little_endian_int32(&p_ntag->data[88]);
+
+        if (!is_valid_amiibo_v3(head, tail)) {
+            return NTAG_215;
+        }
+    }
+
+    return _ntag_type(size);
+}
 
 int32_t amiidb_api_slot_read(uint8_t slot, ntag_t *p_ntag) {
     char path[VFS_MAX_PATH_LEN];
@@ -21,12 +35,13 @@ int32_t amiidb_api_slot_read(uint8_t slot, ntag_t *p_ntag) {
 
     memset(&meta, 0, sizeof(vfs_meta_t));
     vfs_meta_decode(fd.meta, sizeof(fd.meta), &meta);
+    memset(p_ntag, 0, sizeof(ntag_t));
     int32_t res = p_vfs_driver->read_file_data(path, p_ntag->data, sizeof(p_ntag->data));
-    if (res < 0) {
+    if (res < 0 || !is_valid_amiibo_ntag_by_size(res)) {
         return -1;
     }
 
-    p_ntag->type = _ntag_type(res);
+    p_ntag->type = amiidb_api_slot_get_tag_type(res, &meta, p_ntag);
 
     if (meta.has_notes) {
         strcpy(p_ntag->notes, meta.notes);
@@ -46,8 +61,9 @@ int32_t amiidb_api_slot_write(uint8_t slot, ntag_t *p_ntag) {
 
     sprintf(path, "/amiibo/data/%02d.bin", slot);
     vfs_driver_t *p_vfs_driver = vfs_get_driver(VFS_DRIVE_EXT);
-    int32_t res = p_vfs_driver->write_file_data(path, p_ntag->data, sizeof(p_ntag->data));
-    if (res < 0) {
+    size_t tag_size = _ntag_data_size(p_ntag);
+    int32_t res = p_vfs_driver->write_file_data(path, p_ntag->data, tag_size);
+    if (res != (int32_t)tag_size) {
         // TODO msg box
         return -1;
     }


### PR DESCRIPTION
## Summary
- save Amiibo Database data slots using the actual tag size instead of the internal buffer size
- validate slot file sizes when loading saved database slots
- treat legacy 2048-byte saved slots as NTAG215 when the saved amiibo id is not a V3 amiibo

## Root Cause
Amiibo Database generates normal NTAG215 amiibo in memory correctly, so selecting directly from the database works.

The problem happens after `Save as`: `amiidb_api_slot_write()` wrote `sizeof(p_ntag->data)`. After V3 / NTAG I2C 2K support, the internal `ntag_t.data` buffer became 2048 bytes. That means a normal 540-byte NTAG215 amiibo saved from the database could become a 2048-byte file.

When the saved slot is loaded later from `My Amiibo`, `amiidb_api_slot_read()` infers the tag type from the file size. A mistakenly 2048-byte saved NTAG215 tag is then treated as `NTAG_I2C_PLUS_2K`, which can make consoles such as new 3DS reject it even though the same generated amiibo worked directly from the database.

This PR writes `_ntag_data_size(p_ntag)` instead of the full internal buffer size. It also keeps existing affected slots usable by mapping 2048-byte saved slots back to NTAG215 when their amiibo id is not a V3 amiibo.

Closes #421

## Test Plan
- `git diff --check origin/develop...HEAD`
- inspected the Amiibo Emulator save path, which already writes `_ntag_data_size(p_ntag)`
- local firmware build not run successfully due the same local SDK/toolchain blocker seen in recent firmware PRs: missing vendored `external/mbedtls` sources/includes and `arm-none-eabi-gcc` could not find `stdint.h`