### PR TITLE
feat(settings): add flip-screen support

### DIFF
--- a/fw/application/src/app/settings/scene/settings_scene_main.c
+++ b/fw/application/src/app/settings/scene/settings_scene_main.c
@@ -30,7 +30,6 @@ enum settings_main_menu_t {
 };
 
 static void settings_scene_main_reload(void *user_data);
-static const char *SETTINGS_LABEL_DISPLAY_FLIP = "Flip Screen";
 
 static void settings_reset_default(void *user_data) {
     app_settings_t *app = user_data;
@@ -187,7 +186,7 @@ static void settings_scene_main_reload(void *user_data) {
     mui_list_view_add_item_ext(app->p_list_view, 0xe1c8, _T(APP_SET_OLED_CONTRAST), txt,
                                (void *)SETTINGS_MAIN_MENU_OLED_CONTRAST);
 
-    mui_list_view_add_item_ext(app->p_list_view, 0xe16d, SETTINGS_LABEL_DISPLAY_FLIP,
+    mui_list_view_add_item_ext(app->p_list_view, 0xe16d, _T(APP_SET_DISPLAY_FLIP),
                                p_settings->display_flip ? _T(ON_F) : _T(OFF_F),
                                (void *)SETTINGS_MAIN_MENU_DISPLAY_FLIP);
 

--- a/fw/application/src/app/settings/scene/settings_scene_main.c
+++ b/fw/application/src/app/settings/scene/settings_scene_main.c
@@ -12,6 +12,7 @@ enum settings_main_menu_t {
     SETTINGS_MAIN_MENU_VERSION,
     SETTINGS_MAIN_MENU_BACK_LIGHT,
     SETTINGS_MAIN_MENU_OLED_CONTRAST,
+    SETTINGS_MAIN_MENU_DISPLAY_FLIP,
     SETTINGS_MAIN_MENU_LI_MODE,
     SETTINGS_MAIN_MENU_ENABLE_HIBERNATE,
     SETTINGS_MAIN_MENU_STORAGE,
@@ -29,9 +30,12 @@ enum settings_main_menu_t {
 };
 
 static void settings_scene_main_reload(void *user_data);
+static const char *SETTINGS_LABEL_DISPLAY_FLIP = "Flip Screen";
+
 static void settings_reset_default(void *user_data) {
     app_settings_t *app = user_data;
     settings_data_t *p_settings = settings_get_data();
+    mui_u8g2_set_display_flip(p_settings->display_flip);
     mui_u8g2_set_contrast_level(p_settings->oled_contrast);
 #ifdef LCD_SCREEN
     mui_u8g2_set_backlight_level(p_settings->lcd_backlight);
@@ -69,6 +73,12 @@ static void settings_scene_main_list_view_on_selected(mui_list_view_event_t even
 
     case SETTINGS_MAIN_MENU_OLED_CONTRAST:
         mui_scene_dispatcher_next_scene(app->p_scene_dispatcher, SETTINGS_SCENE_OLED_CONTRAST);
+        break;
+
+    case SETTINGS_MAIN_MENU_DISPLAY_FLIP:
+        p_settings->display_flip = !p_settings->display_flip;
+        mui_u8g2_set_display_flip(p_settings->display_flip);
+        settings_scene_main_reload(app);
         break;
 
     case SETTINGS_MAIN_MENU_VERSION:
@@ -176,6 +186,10 @@ static void settings_scene_main_reload(void *user_data) {
     snprintf(txt, sizeof(txt), "[%d%%]", p_settings->oled_contrast);
     mui_list_view_add_item_ext(app->p_list_view, 0xe1c8, _T(APP_SET_OLED_CONTRAST), txt,
                                (void *)SETTINGS_MAIN_MENU_OLED_CONTRAST);
+
+    mui_list_view_add_item_ext(app->p_list_view, 0xe16d, SETTINGS_LABEL_DISPLAY_FLIP,
+                               p_settings->display_flip ? _T(ON_F) : _T(OFF_F),
+                               (void *)SETTINGS_MAIN_MENU_DISPLAY_FLIP);
 
 #ifdef LCD_SCREEN
     if (p_settings->lcd_backlight == 0) {

--- a/fw/application/src/i18n/en_US.c
+++ b/fw/application/src/i18n/en_US.c
@@ -38,6 +38,7 @@ const char * const lang_en_US[_L_COUNT] = {
     [_L_APP_SET_ABOUT_OPEN_SOURCE_PROJECT] = "Open Source Project",
     [_L_APP_SET_ABOUT_LGPL_LICENSE] = "GPL 2.0 License",
     [_L_APP_SET_APP_MGMT] = "App Management",
+    [_L_APP_SET_DISPLAY_FLIP] = "Flip Screen",
     [_L_15S] = "15 Seconds",
     [_L_30S] = "30 Seconds",
     [_L_45S] = "45 Seconds",

--- a/fw/application/src/i18n/string_id.h
+++ b/fw/application/src/i18n/string_id.h
@@ -39,6 +39,7 @@ typedef enum {
     _L_APP_SET_ABOUT_OPEN_SOURCE_PROJECT,
     _L_APP_SET_ABOUT_LGPL_LICENSE,
     _L_APP_SET_APP_MGMT,
+    _L_APP_SET_DISPLAY_FLIP,
     _L_15S,
     _L_30S,
     _L_45S,

--- a/fw/application/src/mod/settings.c
+++ b/fw/application/src/mod/settings.c
@@ -34,9 +34,9 @@ const settings_data_t def_settings_data = {.backlight = 0,
                                            .chameleon_default_slot_index = INVALID_SLOT_INDEX,
                                             .app_enable_bits = 0xFFFF,
                                             .amiidb_sort_column = 0,
-                                            .chameleon_slot_num = 8,
-                                            .amiibolink_mode = 0, // 0 = not set, use default (manual)
-                                        };
+                                           .chameleon_slot_num = 8,
+                                           .amiibolink_mode = 0, // 0 = not set, use default (manual)
+                                           .display_flip = false};
 
 settings_data_t m_settings_data = {0};
 
@@ -71,6 +71,7 @@ static void validate_settings() {
     INT8_VALIDATE(m_settings_data.oled_contrast, 0, 100, 80);
     BOOL_VALIDATE(m_settings_data.anim_enabled, 0);
     BOOL_VALIDATE(m_settings_data.qrcode_enabled, 0);
+    BOOL_VALIDATE(m_settings_data.display_flip, 0);
     INT8_VALIDATE(m_settings_data.language, 0, LANGUAGE_COUNT - 1, LANGUAGE_EN_US);
     INT8_VALIDATE(m_settings_data.amiidb_data_slot_num, 1, 100, 20);
     INT8_VALIDATE(m_settings_data.chameleon_slot_num, 8, 50, 8);

--- a/fw/application/src/mod/settings.c
+++ b/fw/application/src/mod/settings.c
@@ -8,6 +8,16 @@
 #include "ble_amiibolink.h"
 
 #define SETTINGS_FILE_NAME "/settings.bin"
+#define SETTINGS_FILE_MAGIC 0x31544753u // "STG1"
+#define SETTINGS_FILE_VERSION 1
+
+typedef struct {
+    uint32_t magic;
+    uint16_t version;
+    uint16_t payload_size;
+} settings_file_header_t;
+
+#define SETTINGS_SERIALIZED_MAX_SIZE (sizeof(settings_file_header_t) + sizeof(settings_data_t))
 
 #ifdef OLED_SCREEN
 // Though OLED doesn't necessarily imply rechargeable battery, it's usually the case.
@@ -87,6 +97,50 @@ static void validate_settings() {
     }
 }
 
+static size_t settings_serialize_current(uint8_t *buffer, size_t buffer_size) {
+    if (buffer_size < SETTINGS_SERIALIZED_MAX_SIZE) {
+        return 0;
+    }
+
+    settings_file_header_t header = {.magic = SETTINGS_FILE_MAGIC,
+                                     .version = SETTINGS_FILE_VERSION,
+                                     .payload_size = sizeof(settings_data_t)};
+    memcpy(buffer, &header, sizeof(header));
+    memcpy(buffer + sizeof(header), &m_settings_data, sizeof(settings_data_t));
+    return SETTINGS_SERIALIZED_MAX_SIZE;
+}
+
+static bool settings_try_deserialize_versioned(const uint8_t *buffer, size_t buffer_size, settings_data_t *out) {
+    if (buffer_size < sizeof(settings_file_header_t)) {
+        return false;
+    }
+
+    const settings_file_header_t *header = (const settings_file_header_t *)buffer;
+    if (header->magic != SETTINGS_FILE_MAGIC || header->version != SETTINGS_FILE_VERSION) {
+        return false;
+    }
+
+    if (header->payload_size != sizeof(settings_data_t)) {
+        return false;
+    }
+
+    size_t expected_size = sizeof(settings_file_header_t) + header->payload_size;
+    if (buffer_size < expected_size) {
+        return false;
+    }
+
+    memcpy(out, buffer + sizeof(settings_file_header_t), sizeof(settings_data_t));
+    return true;
+}
+
+static bool settings_deserialize_legacy(const uint8_t *buffer, size_t buffer_size, settings_data_t *out) {
+    if (buffer_size == 0 || buffer_size > sizeof(settings_data_t)) {
+        return false;
+    }
+    memcpy(out, buffer, buffer_size);
+    return true;
+}
+
 int32_t settings_init() {
     memcpy(&m_settings_data, &def_settings_data, sizeof(settings_data_t));
     vfs_driver_t *p_driver = vfs_get_default_driver();
@@ -102,9 +156,45 @@ int32_t settings_init() {
         return NRF_ERROR_INVALID_STATE;
     }
 
-    err = p_driver->read_file_data(SETTINGS_FILE_NAME, &m_settings_data, sizeof(settings_data_t));
+    vfs_obj_t settings_obj = {0};
+    err = p_driver->stat_file(SETTINGS_FILE_NAME, &settings_obj);
+    if (err == VFS_ERR_NOOBJ) {
+        validate_settings();
+        NRF_LOG_INFO("settings not found, using defaults");
+        return NRF_SUCCESS;
+    }
     if (err < 0) {
         return NRF_ERROR_INVALID_STATE;
+    }
+
+    if (settings_obj.size == 0) {
+        validate_settings();
+        NRF_LOG_INFO("settings empty, using defaults");
+        return NRF_SUCCESS;
+    }
+
+    uint8_t settings_raw[SETTINGS_SERIALIZED_MAX_SIZE];
+    size_t read_size_target = settings_obj.size;
+    if (read_size_target > sizeof(settings_raw)) {
+        read_size_target = sizeof(settings_raw);
+    }
+
+    err = p_driver->read_file_data(SETTINGS_FILE_NAME, settings_raw, read_size_target);
+    if (err < 0) {
+        return NRF_ERROR_INVALID_STATE;
+    }
+
+    size_t read_size = (size_t)err;
+    bool loaded = settings_try_deserialize_versioned(settings_raw, read_size, &m_settings_data);
+    if (!loaded) {
+        loaded = settings_deserialize_legacy(settings_raw, read_size, &m_settings_data);
+        if (loaded) {
+            NRF_LOG_INFO("settings migrated from legacy layout");
+        }
+    }
+
+    if (!loaded) {
+        NRF_LOG_WARNING("settings invalid, using defaults");
     }
 
     validate_settings();
@@ -121,19 +211,40 @@ int32_t settings_save() {
         return NRF_ERROR_NOT_SUPPORTED;
     }
 
-    settings_data_t old_settings_data;
-
-    err = p_driver->read_file_data(SETTINGS_FILE_NAME, &old_settings_data, sizeof(settings_data_t));
+    uint8_t old_settings_raw[SETTINGS_SERIALIZED_MAX_SIZE];
+    size_t old_settings_size = 0;
+    vfs_obj_t settings_obj = {0};
+    err = p_driver->stat_file(SETTINGS_FILE_NAME, &settings_obj);
     bool not_found = false;
     if (err == VFS_ERR_NOOBJ) {
         not_found = true;
     } else if (err < 0) {
         return NRF_ERROR_INVALID_STATE;
+    } else if (settings_obj.size > 0) {
+        old_settings_size = settings_obj.size;
+        if (old_settings_size > sizeof(old_settings_raw)) {
+            old_settings_size = sizeof(old_settings_raw);
+        }
+
+        err = p_driver->read_file_data(SETTINGS_FILE_NAME, old_settings_raw, old_settings_size);
+        if (err < 0) {
+            return NRF_ERROR_INVALID_STATE;
+        }
+        old_settings_size = (size_t)err;
     }
 
-    if (not_found || memcmp(&m_settings_data, &old_settings_data, sizeof(settings_data_t)) != 0) {
-        err = p_driver->write_file_data(SETTINGS_FILE_NAME, &m_settings_data, sizeof(settings_data_t));
-        if (err < 0) {
+    uint8_t new_settings_raw[SETTINGS_SERIALIZED_MAX_SIZE];
+    size_t new_settings_size = settings_serialize_current(new_settings_raw, sizeof(new_settings_raw));
+    if (new_settings_size == 0) {
+        return NRF_ERROR_INVALID_STATE;
+    }
+
+    bool needs_write = not_found || old_settings_size != new_settings_size ||
+                       memcmp(new_settings_raw, old_settings_raw, new_settings_size) != 0;
+
+    if (needs_write) {
+        err = p_driver->write_file_data(SETTINGS_FILE_NAME, new_settings_raw, new_settings_size);
+        if (err < 0 || (size_t)err != new_settings_size) {
             return NRF_ERROR_INVALID_STATE;
         }
 

--- a/fw/application/src/mod/settings.h
+++ b/fw/application/src/mod/settings.h
@@ -33,6 +33,7 @@ typedef struct {
     uint8_t amiidb_sort_column;
     uint8_t chameleon_slot_num; // chameleon available slot count (8-50)
     ble_amiibolink_mode_t amiibolink_mode; // user's preferred AmiiboLink mode (0 = not set, use default)
+    bool display_flip; // rotate screen by 180 degrees
 } settings_data_t;
 
 int32_t settings_init();

--- a/fw/application/src/mui/mui_u8g2.c
+++ b/fw/application/src/mui/mui_u8g2.c
@@ -84,6 +84,8 @@ u8g2_t u8g2;
 static spi_device_t m_dev;
 uint8_t m_u8g2_initialized = 0;
 
+static const u8g2_cb_t *mui_u8g2_get_rotation_cb(bool flipped) { return flipped ? U8G2_R2 : U8G2_R0; }
+
 #ifdef LCD_SCREEN
 APP_PWM_INSTANCE(pwm1, 1); // Create the instance "PWM1" using TIMER1.
 
@@ -182,6 +184,9 @@ uint8_t u8x8_HW_com_spi_nrf52832(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, voi
     return 1;
 }
 void mui_u8g2_init(u8g2_t *p_u8g2) {
+    settings_data_t *p_settings = settings_get_data();
+    const u8g2_cb_t *rotation = mui_u8g2_get_rotation_cb(p_settings->display_flip);
+
     m_dev.cs_pin = LCD_CS_PIN;
     hal_spi_bus_attach(&m_dev);
 
@@ -192,11 +197,10 @@ void mui_u8g2_init(u8g2_t *p_u8g2) {
     nrf_gpio_cfg_output(LCD_BL_PIN);
     nrf_gpio_pin_clear(LCD_BL_PIN);
 
-    u8g2_Setup_st7567_enh_dg128064_f(p_u8g2, U8G2_R0, u8x8_HW_com_spi_nrf52832, u8g2_nrf_gpio_and_delay_spi_cb);
+    u8g2_Setup_st7567_enh_dg128064_f(p_u8g2, rotation, u8x8_HW_com_spi_nrf52832, u8g2_nrf_gpio_and_delay_spi_cb);
 
     u8g2_InitDisplay(p_u8g2);
 
-    settings_data_t *p_settings = settings_get_data();
     mui_u8g2_set_contrast_level(p_settings->oled_contrast);
 
     u8g2_SetPowerSave(p_u8g2, 0);
@@ -205,10 +209,9 @@ void mui_u8g2_init(u8g2_t *p_u8g2) {
 #endif
 
 #ifdef OLED_SCREEN
-    u8g2_Setup_sh1106_128x64_noname_f(p_u8g2, U8G2_R0, u8x8_HW_com_spi_nrf52832, u8g2_nrf_gpio_and_delay_spi_cb);
+    u8g2_Setup_sh1106_128x64_noname_f(p_u8g2, rotation, u8x8_HW_com_spi_nrf52832, u8g2_nrf_gpio_and_delay_spi_cb);
     u8g2_InitDisplay(p_u8g2);
 
-    settings_data_t *p_settings = settings_get_data();
     mui_u8g2_set_contrast_level(p_settings->oled_contrast);
 
     u8g2_SetPowerSave(p_u8g2, 0);
@@ -256,6 +259,17 @@ void mui_u8g2_set_contrast_level(uint8_t value) {
     }
 #endif
     u8g2_SetContrast(&p_mui->u8g2, (value - 1) * (255.0 / 99.0));
+}
+
+void mui_u8g2_set_display_flip(bool enabled) {
+    mui_t *p_mui = mui();
+    if (!p_mui->initialized) {
+        return;
+    }
+
+    u8g2_SetDisplayRotation(&p_mui->u8g2, mui_u8g2_get_rotation_cb(enabled));
+    u8g2_ClearBuffer(&p_mui->u8g2);
+    u8g2_SendBuffer(&p_mui->u8g2);
 }
 
 const spi_device_t *mui_u8g2_get_spi_device() { return &m_dev; }

--- a/fw/application/src/mui/mui_u8g2.h
+++ b/fw/application/src/mui/mui_u8g2.h
@@ -1,6 +1,8 @@
 #ifndef MUI_U8G2_H
 #define MUI_U8G2_H
 
+#include <stdbool.h>
+
 #include "mui_defines.h"
 #include "hal_spi_bus.h"
 #include "u8g2.h"
@@ -16,6 +18,7 @@ int8_t mui_u8g2_get_backlight_level(void);
 void mui_u8g2_set_lcd_default_contrast_level(void);
 
 void mui_u8g2_set_contrast_level(uint8_t value);
+void mui_u8g2_set_display_flip(bool enabled);
 
 const spi_device_t* mui_u8g2_get_spi_device();
 


### PR DESCRIPTION
## Summary
- add persistent Flip Screen setting in Settings
- apply runtime display rotation for OLED/LCD
- persist and validate setting in settings.bin

## Scope
- only flip-screen feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Flip Screen" setting to toggle display orientation.
  * Changes apply immediately and persist across power cycles.
  * Added localized label for the new setting.

* **Bug Fixes**
  * Reset-to-default now correctly restores the flip-screen preference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->